### PR TITLE
feat: Add landsraad_bonus flag for variable conversion rate

### DIFF
--- a/commands/fixedratecut.py
+++ b/commands/fixedratecut.py
@@ -21,7 +21,7 @@ from utils.helpers import get_database, get_sand_per_melange, send_response
 from utils.logger import logger
 
 @handle_interaction_expiration
-async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, use_followup: bool = True):
+async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, landsraad_bonus: bool = False, use_followup: bool = True):
     """Awards a fixed percentage of spice sand to tagged users, with the remainder going to the guild."""
     try:
         # Validate inputs
@@ -59,7 +59,7 @@ async def fixedratecut(interaction, total_sand: int, users: str, rate: int = 5, 
         guild_sand = total_sand - total_user_sand
 
         # Get conversion rate
-        sand_per_melange = get_sand_per_melange()
+        sand_per_melange = get_sand_per_melange(landsraad_bonus=landsraad_bonus)
 
         # Ensure the initiator exists in the users table
         from utils.database_utils import validate_user_exists

--- a/commands/sand.py
+++ b/commands/sand.py
@@ -18,7 +18,7 @@ from utils.helpers import get_database, get_sand_per_melange, send_response
 
 
 @handle_interaction_expiration
-async def sand(interaction, amount: int, use_followup: bool = True):
+async def sand(interaction, amount: int, landsraad_bonus: bool = False, use_followup: bool = True):
     """Convert spice sand into melange (primary currency)"""
     command_start = time.time()
     
@@ -28,7 +28,7 @@ async def sand(interaction, amount: int, use_followup: bool = True):
         return
     
     # Get conversion rate and add deposit
-    sand_per_melange = get_sand_per_melange()
+    sand_per_melange = get_sand_per_melange(landsraad_bonus=landsraad_bonus)
     
     # Database operations with timing using utility functions
     

--- a/commands/split.py
+++ b/commands/split.py
@@ -22,7 +22,7 @@ from utils.logger import logger
 
 
 @handle_interaction_expiration
-async def split(interaction, total_sand: int, users: str, guild: int = 10, use_followup: bool = True):
+async def split(interaction, total_sand: int, users: str, guild: int = 10, landsraad_bonus: bool = False, use_followup: bool = True):
     """Split spice sand among expedition members and convert to melange with guild cut"""
     
     try:
@@ -113,7 +113,7 @@ async def split(interaction, total_sand: int, users: str, guild: int = 10, use_f
             return
         
         # Get conversion rate
-        sand_per_melange = get_sand_per_melange()
+        sand_per_melange = get_sand_per_melange(landsraad_bonus=landsraad_bonus)
         
         # Ensure the initiator exists in the users table
         from utils.database_utils import validate_user_exists

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -111,6 +111,39 @@ class TestCommandResponsiveness:
             except Exception as e:
                 pytest.fail(f"Command {function_name} failed with error on invalid input: {e}")
 
+    @pytest.mark.asyncio
+    async def test_landsraad_bonus_sand_command(self, mock_interaction, mock_database):
+        """Test the sand command with the landsraad_bonus flag."""
+        from commands.sand import sand
+        with patch('commands.sand.get_sand_per_melange') as mock_get_sand_per_melange, \
+             patch('commands.sand.get_database', return_value=mock_database):
+
+            mock_get_sand_per_melange.return_value = 37
+            await sand(mock_interaction, 100, landsraad_bonus=True)
+            mock_get_sand_per_melange.assert_called_with(landsraad_bonus=True)
+
+    @pytest.mark.asyncio
+    async def test_landsraad_bonus_split_command(self, mock_interaction, mock_database):
+        """Test the split command with the landsraad_bonus flag."""
+        from commands.split import split
+        with patch('commands.split.get_sand_per_melange') as mock_get_sand_per_melange, \
+             patch('commands.split.get_database', return_value=mock_database):
+
+            mock_get_sand_per_melange.return_value = 37
+            await split(mock_interaction, 1000, '<@12345>', 10, landsraad_bonus=True)
+            mock_get_sand_per_melange.assert_called_with(landsraad_bonus=True)
+
+    @pytest.mark.asyncio
+    async def test_landsraad_bonus_fixedratecut_command(self, mock_interaction, mock_database):
+        """Test the fixedratecut command with the landsraad_bonus flag."""
+        from commands.fixedratecut import fixedratecut
+        with patch('commands.fixedratecut.get_sand_per_melange') as mock_get_sand_per_melange, \
+             patch('commands.fixedratecut.get_database', return_value=mock_database):
+
+            mock_get_sand_per_melange.return_value = 37
+            await fixedratecut(mock_interaction, 10000, '<@12345>', 5, landsraad_bonus=True)
+            mock_get_sand_per_melange.assert_called_with(landsraad_bonus=True)
+
     def test_command_metadata_structure(self):
         """Test that all commands have proper metadata structure."""
         for command_name, metadata in COMMAND_METADATA.items():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,9 +42,13 @@ class TestHelpers:
     
     def test_get_sand_per_melange(self):
         """Test getting sand per melange conversion rate."""
+        # Test default rate
         rate = get_sand_per_melange()
-        assert isinstance(rate, int)
-        assert rate > 0
+        assert rate == 50
+
+        # Test Landsraad bonus rate
+        rate = get_sand_per_melange(landsraad_bonus=True)
+        assert rate == 37
     
     @pytest.mark.asyncio
     async def test_send_response_interaction(self, mock_interaction):

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -24,9 +24,10 @@ def get_sand_per_melange(landsraad_bonus: bool = False) -> int:
     - Default rate: 50 sand per melange
     - Landsraad bonus rate: 37 sand per melange
     """
+    LANDSRAAD_BONUS_RATE = 37
     if landsraad_bonus:
-        return 37
-    return 50
+        return LANDSRAAD_BONUS_RATE
+    return SAND_PER_MELANGE
 
 async def send_response(interaction, content=None, embed=None, ephemeral=False, use_followup=True):
     """Helper function to send responses using the appropriate method based on use_followup"""

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -18,9 +18,15 @@ def get_database():
 # Sand to melange conversion rate (implementation detail)
 SAND_PER_MELANGE = 50
 
-def get_sand_per_melange() -> int:
-    """Get the spice sand to melange conversion rate (hardcoded constant)"""
-    return SAND_PER_MELANGE
+def get_sand_per_melange(landsraad_bonus: bool = False) -> int:
+    """
+    Get the spice sand to melange conversion rate.
+    - Default rate: 50 sand per melange
+    - Landsraad bonus rate: 37 sand per melange
+    """
+    if landsraad_bonus:
+        return 37
+    return 50
 
 async def send_response(interaction, content=None, embed=None, ephemeral=False, use_followup=True):
     """Helper function to send responses using the appropriate method based on use_followup"""


### PR DESCRIPTION
This commit introduces a new optional boolean flag `landsraad_bonus` to the `sand`, `split`, and `fixedratecut` commands.

When `landsraad_bonus` is set to `True`, the conversion rate from sand to melange is changed from 50 to 37. This allows for a dynamic conversion rate based on in-game events.

The changes include:
- Modifying `utils.helpers.get_sand_per_melange` to accept the `landsraad_bonus` parameter.
- Updating the `sand`, `split`, and `fixedratecut` commands to accept the new flag and pass it to the helper function.
- Updating the tests to cover the new functionality.