### PR TITLE
Fix guild_withdraw command and subsequent logging error

### DIFF
--- a/database.py
+++ b/database.py
@@ -332,12 +332,12 @@ class Database:
                         VALUES ('withdrawal', $1, $2, $3, $4, $5, $6)
                     ''', melange_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal of {melange_amount} melange to {target_username}")
 
-                await self._log_operation("update", "guild_treasury", start_time, success=True,
-                                        operation="withdrawal", melange_amount=melange_amount, target_user_id=target_user_id)
+                await self._log_operation("withdrawal", "guild_treasury", start_time, success=True,
+                                        melange_amount=melange_amount, target_user_id=target_user_id)
                 return True
             except Exception as e:
-                await self._log_operation("update", "guild_treasury", start_time, success=False,
-                                        operation="withdrawal", melange_amount=melange_amount, target_user_id=target_user_id, error=str(e))
+                await self._log_operation("withdrawal", "guild_treasury", start_time, success=False,
+                                        melange_amount=melange_amount, target_user_id=target_user_id, error=str(e))
                 raise e
 
     async def add_expedition_participant(self, expedition_id, user_id, username, sand_amount, melange_amount, is_harvester=False):


### PR DESCRIPTION
The guild_withdraw command was erroring out. This commit fixes the command to use 'melange' instead of 'sand', correctly updates the user and guild balances, and resolves a follow-up bug in the database logging.

- The `guild_withdraw` command now correctly withdraws 'melange' from the guild treasury and adds it to the user's `total_melange`.
- All user-facing text for the command has been updated to refer to 'melange'.
- A bug in the `_log_operation` call within `guild_withdraw` has been fixed, resolving a `TypeError`.
- The `get_sand_per_melange` function in `utils/helpers.py` has been corrected to return `37.5` as a float, and its corresponding test and docstring have been updated to match, per user feedback.