### PR TITLE
Fix guild_withdraw command and database errors

### DIFF
--- a/database.py
+++ b/database.py
@@ -328,9 +328,9 @@ class Database:
 
                     # Record transaction in guild_transactions
                     await conn.execute('''
-                        INSERT INTO guild_transactions (transaction_type, melange_amount, admin_user_id, admin_username, target_user_id, target_username, description)
-                        VALUES ('withdrawal', $1, $2, $3, $4, $5, $6)
-                    ''', melange_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal of {melange_amount} melange to {target_username}")
+                        INSERT INTO guild_transactions (transaction_type, sand_amount, melange_amount, admin_user_id, admin_username, target_user_id, target_username, description)
+                        VALUES ('withdrawal', $1, $2, $3, $4, $5, $6, $7)
+                    ''', 0, melange_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal of {melange_amount} melange to {target_username}")
 
                 await self._log_operation("withdrawal", "guild_treasury", start_time, success=True,
                                         melange_amount=melange_amount, target_user_id=target_user_id)


### PR DESCRIPTION
The guild_withdraw command was erroring out due to several issues. This commit fixes the command to use 'melange' instead of 'sand', correctly updates the user and guild balances, and resolves follow-up bugs in the database logic.

- The `guild_withdraw` command now correctly withdraws 'melange' from the guild treasury and adds it to the user's `total_melange`.
- All user-facing text for the command has been updated to refer to 'melange'.
- A bug in the `_log_operation` call within `guild_withdraw` has been fixed, resolving a `TypeError`.
- A `NOT NULL` constraint violation in the `guild_transactions` table has been fixed by providing a `sand_amount` of `0` for melange withdrawals.
- The `get_sand_per_melange` function in `utils/helpers.py` has been corrected to return `37.5` as a float, and its corresponding test and docstring have been updated to match, per user feedback.