### PR TITLE
Fix/guild withdraw command

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -208,10 +208,10 @@ def register_commands():
         await treasury(interaction, True)
 
     # Guild Withdraw command
-    @bot.tree.command(name="guild_withdraw", description="Withdraw sand from guild treasury to give to a user (Admin only)")
+    @bot.tree.command(name="guild_withdraw", description="Withdraw melange from guild treasury to give to a user (Admin only)")
     @app_commands.describe(
-        user="User to give sand to",
-        amount="Amount of sand to withdraw from guild treasury"
+        user="User to give melange to",
+        amount="Amount of melange to withdraw from guild treasury"
     )
     async def guild_withdraw_cmd(interaction: discord.Interaction, user: discord.Member, amount: int):  # noqa: F841
         await guild_withdraw(interaction, user, amount, True)

--- a/commands/guild_withdraw.py
+++ b/commands/guild_withdraw.py
@@ -1,14 +1,14 @@
 """
-Guild Withdraw command for transferring sand from guild treasury to users (Admin only).
+Guild Withdraw command for transferring melange from guild treasury to users (Admin only).
 """
 
 # Command metadata
 COMMAND_METADATA = {
-    'aliases': [],  # ['withdraw'] - removed for simplicity
-    'description': "Withdraw sand from guild treasury to give to a user (Admin only)",
+    'aliases': [],
+    'description': "Withdraw melange from guild treasury to give to a user (Admin only)",
     'params': {
-        'user': "User to give sand to",
-        'amount': "Amount of sand to withdraw from guild treasury"
+        'user': "User to give melange to",
+        'amount': "Amount of melange to withdraw from guild treasury"
     }
 }
 
@@ -25,36 +25,36 @@ from utils.logger import logger
 
 @handle_interaction_expiration
 async def guild_withdraw(interaction, user: discord.Member, amount: int, use_followup: bool = True):
-    """Withdraw sand from guild treasury and give to a user (Admin only)"""
+    """Withdraw melange from guild treasury and give to a user (Admin only)"""
     command_start = time.time()
-    
+
     # Check if user has admin permissions
     if not is_admin(interaction):
         await send_response(interaction, "❌ You need an admin role to use this command. Contact a server administrator.", use_followup=use_followup, ephemeral=True)
         return
-    
+
     try:
         # Validate amount
         if amount < 1:
-            await send_response(interaction, "❌ Withdrawal amount must be at least 1 sand.", use_followup=use_followup, ephemeral=True)
+            await send_response(interaction, "❌ Withdrawal amount must be at least 1 melange.", use_followup=use_followup, ephemeral=True)
             return
-        
+
         # Get current guild treasury balance
         treasury_data, get_treasury_time = await timed_database_operation(
             "get_guild_treasury",
             get_database().get_guild_treasury
         )
-        
-        current_sand = treasury_data.get('total_sand', 0)
-        if current_sand < amount:
-            await send_response(interaction, 
+
+        current_melange = treasury_data.get('total_melange', 0)
+        if current_melange < amount:
+            await send_response(interaction,
                 f"❌ Insufficient guild treasury funds.\n\n"
-                f"**Available:** {current_sand:,} sand\n"
-                f"**Requested:** {amount:,} sand\n"
-                f"**Shortfall:** {amount - current_sand:,} sand", 
+                f"**Available:** {current_melange:,} melange\n"
+                f"**Requested:** {amount:,} melange\n"
+                f"**Shortfall:** {amount - current_melange:,} melange",
                 use_followup=use_followup, ephemeral=True)
             return
-        
+
         # Perform withdrawal
         _, withdraw_time = await timed_database_operation(
             "guild_withdraw",
@@ -62,32 +62,32 @@ async def guild_withdraw(interaction, user: discord.Member, amount: int, use_fol
             str(interaction.user.id), interaction.user.display_name,
             str(user.id), user.display_name, amount
         )
-        
+
         # Get updated treasury balance
         updated_treasury, _ = await timed_database_operation(
             "get_guild_treasury",
             get_database().get_guild_treasury
         )
-        
+
         # Build response embed
         fields = {
-            "💸 Transaction": f"**Recipient:** {user.display_name} | **Amount:** {amount:,} sand | **Admin:** {interaction.user.display_name}",
-            "🏛️ Treasury": f"**Previous:** {current_sand:,} | **New:** {updated_treasury.get('total_sand', 0):,} | **Available:** {updated_treasury.get('total_sand', 0):,}"
+            "💸 Transaction": f"**Recipient:** {user.display_name} | **Amount:** {amount:,} melange | **Admin:** {interaction.user.display_name}",
+            "🏛️ Treasury": f"**Previous:** {current_melange:,} | **New:** {updated_treasury.get('total_melange', 0):,} | **Available:** {updated_treasury.get('total_melange', 0):,}"
         }
-        
+
         embed = build_status_embed(
             title="✅ Guild Withdrawal Completed",
-            description=f"💰 **{amount:,} sand** transferred from guild treasury to **{user.display_name}**",
+            description=f"💰 **{amount:,} melange** transferred from guild treasury to **{user.display_name}**",
             color=0x00FF00,
             fields=fields,
             timestamp=interaction.created_at
         )
-        
+
         # Send response
         response_start = time.time()
         await send_response(interaction, embed=embed.build(), use_followup=use_followup)
         response_time = time.time() - response_start
-        
+
         # Log metrics
         total_time = time.time() - command_start
         log_command_metrics(
@@ -103,20 +103,20 @@ async def guild_withdraw(interaction, user: discord.Member, amount: int, use_fol
             withdraw_time=f"{withdraw_time:.3f}s",
             response_time=f"{response_time:.3f}s",
             withdrawal_amount=amount,
-            previous_balance=current_sand,
-            new_balance=updated_treasury.get('total_sand', 0)
+            previous_balance=current_melange,
+            new_balance=updated_treasury.get('total_melange', 0)
         )
-        
+
         # Log the withdrawal for audit
-        logger.info(f"Guild withdrawal: {amount:,} sand from treasury to {user.display_name} ({user.id}) by {interaction.user.display_name} ({interaction.user.id})")
-        
+        logger.info(f"Guild withdrawal: {amount:,} melange from treasury to {user.display_name} ({user.id}) by {interaction.user.display_name} ({interaction.user.id})")
+
     except ValueError as ve:
         # Handle insufficient funds or other validation errors
         await send_response(interaction, f"❌ {str(ve)}", use_followup=use_followup, ephemeral=True)
-        
+
     except Exception as error:
         total_time = time.time() - command_start
-        logger.error(f"Error in guild_withdraw command: {error}", 
+        logger.error(f"Error in guild_withdraw command: {error}",
                     user_id=str(interaction.user.id),
                     username=interaction.user.display_name,
                     target_user_id=str(user.id),

--- a/database.py
+++ b/database.py
@@ -332,12 +332,12 @@ class Database:
                         VALUES ('withdrawal', $1, $2, $3, $4, $5, $6)
                     ''', melange_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal of {melange_amount} melange to {target_username}")
 
-                await self._log_operation("update", "guild_treasury", start_time, success=True,
-                                        operation="withdrawal", melange_amount=melange_amount, target_user_id=target_user_id)
+                await self._log_operation("withdrawal", "guild_treasury", start_time, success=True,
+                                        melange_amount=melange_amount, target_user_id=target_user_id)
                 return True
             except Exception as e:
-                await self._log_operation("update", "guild_treasury", start_time, success=False,
-                                        operation="withdrawal", melange_amount=melange_amount, target_user_id=target_user_id, error=str(e))
+                await self._log_operation("withdrawal", "guild_treasury", start_time, success=False,
+                                        melange_amount=melange_amount, target_user_id=target_user_id, error=str(e))
                 raise e
 
     async def add_expedition_participant(self, expedition_id, user_id, username, sand_amount, melange_amount, is_harvester=False):

--- a/database.py
+++ b/database.py
@@ -328,9 +328,9 @@ class Database:
 
                     # Record transaction in guild_transactions
                     await conn.execute('''
-                        INSERT INTO guild_transactions (transaction_type, melange_amount, admin_user_id, admin_username, target_user_id, target_username, description)
-                        VALUES ('withdrawal', $1, $2, $3, $4, $5, $6)
-                    ''', melange_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal of {melange_amount} melange to {target_username}")
+                        INSERT INTO guild_transactions (transaction_type, sand_amount, melange_amount, admin_user_id, admin_username, target_user_id, target_username, description)
+                        VALUES ('withdrawal', $1, $2, $3, $4, $5, $6, $7)
+                    ''', 0, melange_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal of {melange_amount} melange to {target_username}")
 
                 await self._log_operation("withdrawal", "guild_treasury", start_time, success=True,
                                         melange_amount=melange_amount, target_user_id=target_user_id)

--- a/database.py
+++ b/database.py
@@ -11,7 +11,7 @@ class Database:
         self.database_url = database_url or os.getenv('DATABASE_URL')
         if not self.database_url:
             raise ValueError("DATABASE_URL environment variable is required")
-        
+
         # Connection pool settings for better reliability
         self.max_retries = 3
         self.retry_delay = 1.0  # Base delay in seconds
@@ -21,7 +21,7 @@ class Database:
         """Context manager for database connections with retry logic"""
         conn = None
         last_error = None
-        
+
         for attempt in range(self.max_retries):
             start_time = time.time()
             try:
@@ -35,7 +35,7 @@ class Database:
                         'application_name': 'spice_tracker_bot'
                     }
                 )
-                
+
                 connection_time = time.time() - start_time
                 logger.database_operation(
                     operation="connection_established",
@@ -44,7 +44,7 @@ class Database:
                     attempt=attempt + 1,
                     connection_time=f"{connection_time:.3f}s"
                 )
-                
+
                 # Successfully connected, yield and then clean up
                 try:
                     yield conn
@@ -56,7 +56,7 @@ class Database:
                             await asyncio.wait_for(conn.close(), timeout=5.0)
                         except (asyncio.TimeoutError, Exception) as close_error:
                             logger.warning(f"Connection close timeout/failure: {close_error}")
-                            
+
             except Exception as e:
                 last_error = e
                 connection_time = time.time() - start_time
@@ -68,7 +68,7 @@ class Database:
                     connection_time=f"{connection_time:.3f}s",
                     error=str(e)
                 )
-                
+
                 # Close failed connection if it exists
                 if conn and not conn.is_closed():
                     try:
@@ -76,7 +76,7 @@ class Database:
                     except Exception:
                         pass  # Ignore close errors on failed connections
                     conn = None
-                
+
                 if attempt < self.max_retries - 1:
                     # Wait before retrying
                     await asyncio.sleep(self.retry_delay * (attempt + 1))
@@ -105,11 +105,11 @@ class Database:
             async with self._get_connection() as conn:
                 # Simple connectivity test
                 await conn.fetchval('SELECT 1')
-                
+
             init_time = time.time() - start_time
             await self._log_operation("connectivity_check", "database", start_time, success=True, init_time=f"{init_time:.3f}s")
             print(f'✅ Database connected in {init_time:.3f}s')
-            
+
         except Exception as e:
             init_time = time.time() - start_time
             await self._log_operation("connectivity_check", "database", start_time, success=False, init_time=f"{init_time:.3f}s", error=str(e))
@@ -128,7 +128,7 @@ class Database:
                 if row:
                     result = {
                         'user_id': row[0],
-                        'username': row[1], 
+                        'username': row[1],
                         'total_melange': row[2],
                         'last_updated': row[3] if row[3] else datetime.now()
                     }
@@ -165,17 +165,17 @@ class Database:
             try:
                 # Ensure user exists
                 await self.upsert_user(user_id, username)
-                
+
                 # Add deposit record (for history/audit purposes only)
                 await conn.execute('''
                     INSERT INTO deposits (user_id, username, sand_amount, type, expedition_id, created_at)
                     VALUES ($1, $2, $3, $4, $5, CURRENT_TIMESTAMP)
                 ''', user_id, username, sand_amount, deposit_type, expedition_id)
-                
-                await self._log_operation("insert", "deposits", start_time, success=True, 
+
+                await self._log_operation("insert", "deposits", start_time, success=True,
                                         user_id=user_id, sand_amount=sand_amount, deposit_type=deposit_type, expedition_id=expedition_id)
             except Exception as e:
-                await self._log_operation("insert", "deposits", start_time, success=False, 
+                await self._log_operation("insert", "deposits", start_time, success=False,
                                         user_id=user_id, sand_amount=sand_amount, deposit_type=deposit_type, expedition_id=expedition_id, error=str(e))
                 raise e
 
@@ -186,13 +186,13 @@ class Database:
             try:
                 query = '''
                     SELECT id, user_id, username, sand_amount, type, expedition_id, created_at
-                    FROM deposits 
+                    FROM deposits
                     WHERE user_id = $1
                     ORDER BY created_at DESC
                 '''
-                
+
                 rows = await conn.fetch(query, user_id)
-                
+
                 deposits = []
                 for row in rows:
                     deposits.append({
@@ -204,12 +204,12 @@ class Database:
                         'expedition_id': row[5],
                         'created_at': row[6]
                     })
-                
-                await self._log_operation("select", "deposits", start_time, success=True, 
+
+                await self._log_operation("select", "deposits", start_time, success=True,
                                         user_id=user_id, result_count=len(deposits))
                 return deposits
             except Exception as e:
-                await self._log_operation("select", "deposits", start_time, success=False, 
+                await self._log_operation("select", "deposits", start_time, success=False,
                                         user_id=user_id, error=str(e))
                 raise e
 
@@ -223,13 +223,13 @@ class Database:
                     VALUES ($1, $2, $3, $4, $5)
                     RETURNING id
                 ''', initiator_id, initiator_username, total_sand, sand_per_melange, guild_cut_percentage)
-                
+
                 expedition_id = row[0] if row else None
-                await self._log_operation("insert", "expeditions", start_time, success=True, 
+                await self._log_operation("insert", "expeditions", start_time, success=True,
                                         initiator_id=initiator_id, total_sand=total_sand, expedition_id=expedition_id, guild_cut_percentage=guild_cut_percentage)
                 return expedition_id
             except Exception as e:
-                await self._log_operation("insert", "expeditions", start_time, success=False, 
+                await self._log_operation("insert", "expeditions", start_time, success=False,
                                         initiator_id=initiator_id, total_sand=total_sand, error=str(e))
                 raise e
 
@@ -244,7 +244,7 @@ class Database:
                     ORDER BY id DESC
                     LIMIT 1
                 ''')
-                
+
                 if row:
                     treasury = {
                         'total_sand': row['total_sand'],
@@ -259,7 +259,7 @@ class Database:
                         VALUES ($1, $2)
                     ''', 0, 0)
                     treasury = {'total_sand': 0, 'total_melange': 0, 'created_at': None, 'last_updated': None}
-                
+
                 await self._log_operation("select", "guild_treasury", start_time, success=True)
                 return treasury
             except Exception as e:
@@ -274,65 +274,70 @@ class Database:
                 async with conn.transaction():
                     # First try to update existing record
                     result = await conn.execute('''
-                        UPDATE guild_treasury 
+                        UPDATE guild_treasury
                         SET total_sand = total_sand + $1,
                             total_melange = total_melange + $2,
                             last_updated = CURRENT_TIMESTAMP
                     ''', sand_amount, melange_amount)
-                    
+
                     # If no rows were updated, insert initial record
                     if result == 'UPDATE 0':
                         await conn.execute('''
                             INSERT INTO guild_treasury (total_sand, total_melange)
                             VALUES ($1, $2)
                         ''', sand_amount, melange_amount)
-                
-                await self._log_operation("update", "guild_treasury", start_time, success=True, 
+
+                await self._log_operation("update", "guild_treasury", start_time, success=True,
                                         sand_amount=sand_amount, melange_amount=melange_amount)
                 return True
             except Exception as e:
-                await self._log_operation("update", "guild_treasury", start_time, success=False, 
+                await self._log_operation("update", "guild_treasury", start_time, success=False,
                                         sand_amount=sand_amount, melange_amount=melange_amount, error=str(e))
                 raise e
 
-    async def guild_withdraw(self, admin_user_id, admin_username, target_user_id, target_username, sand_amount):
-        """Withdraw sand from guild treasury and give to user"""
+    async def guild_withdraw(self, admin_user_id, admin_username, target_user_id, target_username, melange_amount):
+        """Withdraw melange from guild treasury and give to user"""
         start_time = time.time()
         async with self._get_connection() as conn:
             try:
-                # Check if guild has enough sand
+                # Ensure target user exists, creating them if necessary
+                await self.upsert_user(target_user_id, target_username)
+
+                # Check if guild has enough melange
                 treasury = await self.get_guild_treasury()
-                if treasury['total_sand'] < sand_amount:
-                    raise ValueError(f"Insufficient guild treasury funds. Available: {treasury['total_sand']}, Requested: {sand_amount}")
-                
+                if treasury['total_melange'] < melange_amount:
+                    raise ValueError(f"Insufficient guild treasury funds. Available: {treasury['total_melange']:,}, Requested: {melange_amount:,}")
+
                 # Start transaction
                 async with conn.transaction():
-                    # Remove sand from guild treasury
+                    # Remove melange from guild treasury
                     await conn.execute('''
-                        UPDATE guild_treasury 
-                        SET total_sand = total_sand - $1,
+                        UPDATE guild_treasury
+                        SET total_melange = total_melange - $1,
                             last_updated = CURRENT_TIMESTAMP
                         WHERE id = (SELECT MAX(id) FROM guild_treasury)
-                    ''', sand_amount)
-                    
-                    # Add sand to user as deposit
+                    ''', melange_amount)
+
+                    # Add melange to user's total_melange
                     await conn.execute('''
-                        INSERT INTO deposits (user_id, username, sand_amount, type, paid, created_at, paid_at)
-                        VALUES ($1, $2, $3, 'guild_withdrawal', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-                    ''', target_user_id, target_username, sand_amount)
-                    
-                    # Record transaction
+                        UPDATE users
+                        SET total_melange = total_melange + $1,
+                            last_updated = CURRENT_TIMESTAMP
+                        WHERE user_id = $2
+                    ''', melange_amount, target_user_id)
+
+                    # Record transaction in guild_transactions
                     await conn.execute('''
-                        INSERT INTO guild_transactions (transaction_type, sand_amount, admin_user_id, admin_username, target_user_id, target_username, description)
+                        INSERT INTO guild_transactions (transaction_type, melange_amount, admin_user_id, admin_username, target_user_id, target_username, description)
                         VALUES ('withdrawal', $1, $2, $3, $4, $5, $6)
-                    ''', sand_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal to {target_username}")
-                
-                await self._log_operation("update", "guild_treasury", start_time, success=True, 
-                                        operation="withdrawal", sand_amount=sand_amount, target_user_id=target_user_id)
+                    ''', melange_amount, admin_user_id, admin_username, target_user_id, target_username, f"Guild withdrawal of {melange_amount} melange to {target_username}")
+
+                await self._log_operation("update", "guild_treasury", start_time, success=True,
+                                        operation="withdrawal", melange_amount=melange_amount, target_user_id=target_user_id)
                 return True
             except Exception as e:
-                await self._log_operation("update", "guild_treasury", start_time, success=False, 
-                                        operation="withdrawal", sand_amount=sand_amount, target_user_id=target_user_id, error=str(e))
+                await self._log_operation("update", "guild_treasury", start_time, success=False,
+                                        operation="withdrawal", melange_amount=melange_amount, target_user_id=target_user_id, error=str(e))
                 raise e
 
     async def add_expedition_participant(self, expedition_id, user_id, username, sand_amount, melange_amount, is_harvester=False):
@@ -344,11 +349,11 @@ class Database:
                     INSERT INTO expedition_participants (expedition_id, user_id, username, sand_amount, melange_amount, is_harvester)
                     VALUES ($1, $2, $3, $4, $5, $6)
                 ''', expedition_id, user_id, username, sand_amount, melange_amount, is_harvester)
-                
-                await self._log_operation("insert", "expedition_participants", start_time, success=True, 
+
+                await self._log_operation("insert", "expedition_participants", start_time, success=True,
                                         expedition_id=expedition_id, user_id=user_id, sand_amount=sand_amount, is_harvester=is_harvester)
             except Exception as e:
-                await self._log_operation("insert", "expedition_participants", start_time, success=False, 
+                await self._log_operation("insert", "expedition_participants", start_time, success=False,
                                         expedition_id=expedition_id, user_id=user_id, sand_amount=sand_amount, is_harvester=is_harvester, error=str(e))
                 raise e
 
@@ -359,17 +364,17 @@ class Database:
             try:
                 # Ensure user exists
                 await self.upsert_user(user_id, username)
-                
+
                 # Add deposit record with expedition type
                 await conn.execute('''
                     INSERT INTO deposits (user_id, username, sand_amount, type, expedition_id, created_at)
                     VALUES ($1, $2, $3, 'expedition', $4, CURRENT_TIMESTAMP)
                 ''', user_id, username, sand_amount, expedition_id)
-                
-                await self._log_operation("insert", "deposits", start_time, success=True, 
+
+                await self._log_operation("insert", "deposits", start_time, success=True,
                                         user_id=user_id, sand_amount=sand_amount, expedition_id=expedition_id, type="expedition")
             except Exception as e:
-                await self._log_operation("insert", "deposits", start_time, success=False, 
+                await self._log_operation("insert", "deposits", start_time, success=False,
                                         user_id=user_id, sand_amount=sand_amount, expedition_id=expedition_id, type="expedition", error=str(e))
                 raise e
 
@@ -380,22 +385,22 @@ class Database:
             try:
                 # Get expedition details first
                 expedition_row = await conn.fetchrow('''
-                    SELECT initiator_id, initiator_username, total_sand, guild_cut_percentage, 
+                    SELECT initiator_id, initiator_username, total_sand, guild_cut_percentage,
                            sand_per_melange, created_at
-                    FROM expeditions 
+                    FROM expeditions
                     WHERE id = $1
                 ''', expedition_id)
-                
+
                 if not expedition_row:
                     return None
-                
+
                 # Get participants
                 rows = await conn.fetch('''
-                    SELECT * FROM expedition_participants 
+                    SELECT * FROM expedition_participants
                     WHERE expedition_id = $1
                     ORDER BY is_harvester DESC, username ASC
                 ''', expedition_id)
-                
+
                 participants = []
                 for row in rows:
                     participants.append({
@@ -407,7 +412,7 @@ class Database:
                         'melange_amount': row[5],
                         'is_harvester': bool(row[6])
                     })
-                
+
                 # Combine expedition details with participants
                 result = {
                     'expedition': {
@@ -421,12 +426,12 @@ class Database:
                     },
                     'participants': participants
                 }
-                
-                await self._log_operation("select", "expedition_participants", start_time, success=True, 
+
+                await self._log_operation("select", "expedition_participants", start_time, success=True,
                                         expedition_id=expedition_id, result_count=len(participants))
                 return result
             except Exception as e:
-                await self._log_operation("select", "expedition_participants", start_time, success=False, 
+                await self._log_operation("select", "expedition_participants", start_time, success=False,
                                         expedition_id=expedition_id, error=str(e))
                 raise e
 
@@ -442,14 +447,14 @@ class Database:
                     WHERE d.user_id = $1 AND d.type = 'expedition'
                 '''
                 params = [user_id]
-                
+
                 if not include_paid:
                     query += ' AND d.paid = FALSE'
-                
+
                 query += ' ORDER BY d.created_at DESC'
-                
+
                 rows = await conn.fetch(query, *params)
-                
+
                 deposits = []
                 for row in rows:
                     deposits.append({
@@ -465,12 +470,12 @@ class Database:
                         'initiator_username': row[9] if len(row) > 9 else None,
                         'expedition_total': row[10] if len(row) > 10 else None
                     })
-                
-                await self._log_operation("select", "deposits_join_expeditions", start_time, success=True, 
+
+                await self._log_operation("select", "deposits_join_expeditions", start_time, success=True,
                                         user_id=user_id, include_paid=include_paid, result_count=len(deposits))
                 return deposits
             except Exception as e:
-                await self._log_operation("select", "deposits_join_expeditions", start_time, success=False, 
+                await self._log_operation("select", "deposits_join_expeditions", start_time, success=False,
                                         user_id=user_id, include_paid=include_paid, error=str(e))
                 raise e
 
@@ -483,16 +488,16 @@ class Database:
             try:
                 row = await conn.fetchrow('''
                     SELECT COALESCE(SUM(sand_amount), 0) as total_sand
-                    FROM deposits 
+                    FROM deposits
                     WHERE user_id = $1 AND paid = TRUE
                 ''', user_id)
-                
+
                 total_sand = row[0] if row else 0
-                await self._log_operation("select_sum", "deposits", start_time, success=True, 
+                await self._log_operation("select_sum", "deposits", start_time, success=True,
                                         user_id=user_id, total_sand=total_sand, paid=True)
                 return total_sand
             except Exception as e:
-                await self._log_operation("select_sum", "deposits", start_time, success=False, 
+                await self._log_operation("select_sum", "deposits", start_time, success=False,
                                         user_id=user_id, paid=True, error=str(e))
                 raise e
 
@@ -504,23 +509,23 @@ class Database:
                 async with conn.transaction():
                     # Update user's paid_melange
                     await conn.execute('''
-                        UPDATE users 
+                        UPDATE users
                         SET paid_melange = paid_melange + $1,
                             last_updated = CURRENT_TIMESTAMP
                         WHERE user_id = $2
                     ''', melange_amount, user_id)
-                    
+
                     # Record the payment
                     await conn.execute('''
                         INSERT INTO melange_payments (user_id, username, melange_amount, admin_user_id, admin_username, description)
                         VALUES ($1, $2, $3, $4, $5, $6)
                     ''', user_id, username, melange_amount, admin_user_id, admin_username, f"Melange payment to {username}")
-                
-                await self._log_operation("update", "melange_payments", start_time, success=True, 
+
+                await self._log_operation("update", "melange_payments", start_time, success=True,
                                         user_id=user_id, melange_amount=melange_amount, admin_user_id=admin_user_id)
                 return melange_amount
             except Exception as e:
-                await self._log_operation("update", "melange_payments", start_time, success=False, 
+                await self._log_operation("update", "melange_payments", start_time, success=False,
                                         user_id=user_id, melange_amount=melange_amount, admin_user_id=admin_user_id, error=str(e))
                 raise e
 
@@ -533,39 +538,39 @@ class Database:
                 users_with_pending = await conn.fetch('''
                     SELECT user_id, username, total_melange, paid_melange,
                            (total_melange - paid_melange) as pending_melange
-                    FROM users 
+                    FROM users
                     WHERE total_melange > paid_melange
                 ''')
-                
+
                 total_paid = 0
                 users_paid = 0
-                
+
                 async with conn.transaction():
                     for user in users_with_pending:
                         pending = user['pending_melange']
                         if pending > 0:
                             # Update user's paid_melange
                             await conn.execute('''
-                                UPDATE users 
+                                UPDATE users
                                 SET paid_melange = total_melange,
                                     last_updated = CURRENT_TIMESTAMP
                                 WHERE user_id = $1
                             ''', user['user_id'])
-                            
+
                             # Record the payment
                             await conn.execute('''
-                                INSERT INTO melange_payments (user_id, username, melange_amount, admin_user_id, admin_username, description)
+                                INSERT INTO melange_payments (user_id, username, melange_amount, admin_user_id, admin_username,.description)
                                 VALUES ($1, $2, $3, $4, $5, $6)
                             ''', user['user_id'], user['username'], pending, admin_user_id, admin_username, f"Bulk melange payment to {user['username']}")
-                            
+
                             total_paid += pending
                             users_paid += 1
-                
-                await self._log_operation("update", "melange_payments", start_time, success=True, 
+
+                await self._log_operation("update", "melange_payments", start_time, success=True,
                                         total_paid=total_paid, users_paid=users_paid, admin_user_id=admin_user_id)
                 return {"total_paid": total_paid, "users_paid": users_paid}
             except Exception as e:
-                await self._log_operation("update", "melange_payments", start_time, success=False, 
+                await self._log_operation("update", "melange_payments", start_time, success=False,
                                         admin_user_id=admin_user_id, error=str(e))
                 raise e
 
@@ -575,12 +580,12 @@ class Database:
         async with self._get_connection() as conn:
             try:
                 row = await conn.fetchrow('''
-                    SELECT total_melange, paid_melange, 
+                    SELECT total_melange, paid_melange,
                            (total_melange - paid_melange) as pending_melange
-                    FROM users 
+                    FROM users
                     WHERE user_id = $1
                 ''', user_id)
-                
+
                 if row:
                     result = {
                         'total_melange': row['total_melange'],
@@ -589,12 +594,12 @@ class Database:
                     }
                 else:
                     result = {'total_melange': 0, 'paid_melange': 0, 'pending_melange': 0}
-                
-                await self._log_operation("select", "users", start_time, success=True, 
+
+                await self._log_operation("select", "users", start_time, success=True,
                                         user_id=user_id, pending_melange=result['pending_melange'])
                 return result
             except Exception as e:
-                await self._log_operation("select", "users", start_time, success=False, 
+                await self._log_operation("select", "users", start_time, success=False,
                                         user_id=user_id, error=str(e))
                 raise e
 
@@ -610,7 +615,7 @@ class Database:
                     WHERE u.total_melange > u.paid_melange
                     ORDER BY pending_melange DESC, u.username
                 ''')
-                
+
                 users = []
                 for row in rows:
                     users.append({
@@ -620,8 +625,8 @@ class Database:
                         'paid_melange': row['paid_melange'],
                         'pending_melange': row['pending_melange']
                     })
-                
-                await self._log_operation("select", "users", start_time, success=True, 
+
+                await self._log_operation("select", "users", start_time, success=True,
                                         result_count=len(users))
                 return users
             except Exception as e:
@@ -635,10 +640,10 @@ class Database:
             try:
                 cutoff_date = datetime.now() - timedelta(days=days)
                 result = await conn.execute('''
-                    DELETE FROM deposits 
+                    DELETE FROM deposits
                     WHERE created_at < $1 AND paid = TRUE
                 ''', cutoff_date)
-                
+
                 # Parse the result string to get the count of deleted rows
                 if result:
                     try:
@@ -649,12 +654,12 @@ class Database:
                         deleted_count = 0
                 else:
                     deleted_count = 0
-                
-                await self._log_operation("delete", "deposits", start_time, success=True, 
+
+                await self._log_operation("delete", "deposits", start_time, success=True,
                                         days=days, deleted_count=deleted_count)
                 return deleted_count
             except Exception as e:
-                await self._log_operation("delete", "deposits", start_time, success=False, 
+                await self._log_operation("delete", "deposits", start_time, success=False,
                                         days=days, error=str(e))
                 raise e
 
@@ -664,16 +669,16 @@ class Database:
         async with self._get_connection() as conn:
             try:
                 await conn.execute('''
-                    UPDATE users 
+                    UPDATE users
                     SET total_melange = total_melange + $1,
                         last_updated = CURRENT_TIMESTAMP
                     WHERE user_id = $2
                 ''', melange_amount, user_id)
-                
-                await self._log_operation("update", "users", start_time, success=True, 
+
+                await self._log_operation("update", "users", start_time, success=True,
                                         user_id=user_id, melange_amount=melange_amount)
             except Exception as e:
-                await self._log_operation("update", "users", start_time, success=False, 
+                await self._log_operation("update", "users", start_time, success=False,
                                         user_id=user_id, melange_amount=melange_amount, error=str(e))
                 raise e
 
@@ -686,17 +691,17 @@ class Database:
             try:
                 rows = await conn.fetch('''
                     SELECT username, total_melange
-                    FROM users 
+                    FROM users
                     ORDER BY total_melange DESC, username ASC
                     LIMIT $1
                 ''', limit)
-                
+
                 result = [dict(row) for row in rows]
-                await self._log_operation("select_join", "users_deposits", start_time, success=True, 
+                await self._log_operation("select_join", "users_deposits", start_time, success=True,
                                         limit=limit, result_count=len(result))
                 return result
             except Exception as e:
-                await self._log_operation("select_join", "users_deposits", start_time, success=False, 
+                await self._log_operation("select_join", "users_deposits", start_time, success=False,
                                         limit=limit, error=str(e))
                 raise e
 
@@ -709,13 +714,13 @@ class Database:
                     'SELECT value FROM settings WHERE key = $1',
                     key
                 )
-                
+
                 value = row[0] if row else None
-                await self._log_operation("select", "settings", start_time, success=True, 
+                await self._log_operation("select", "settings", start_time, success=True,
                                         key=key, found=value is not None)
                 return value
             except Exception as e:
-                await self._log_operation("select", "settings", start_time, success=False, 
+                await self._log_operation("select", "settings", start_time, success=False,
                                         key=key, error=str(e))
                 raise e
 
@@ -728,11 +733,11 @@ class Database:
                     'INSERT INTO settings (key, value) VALUES ($1, $2) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value',
                     key, value
                 )
-                
-                await self._log_operation("upsert", "settings", start_time, success=True, 
+
+                await self._log_operation("upsert", "settings", start_time, success=True,
                                         key=key, value=value)
             except Exception as e:
-                await self._log_operation("upsert", "settings", start_time, success=False, 
+                await self._log_operation("upsert", "settings", start_time, success=False,
                                         key=key, value=value, error=str(e))
                 raise e
 
@@ -745,19 +750,19 @@ class Database:
                 # 1. Leaf tables first (no foreign key dependencies)
                 result1 = await conn.execute('DELETE FROM melange_payments')
                 result2 = await conn.execute('DELETE FROM guild_transactions')
-                
+
                 # 2. Tables that reference both expeditions and users
                 result3 = await conn.execute('DELETE FROM expedition_participants')
-                
+
                 # 3. Tables that reference users or expeditions
                 result4 = await conn.execute('DELETE FROM deposits')
-                
+
                 # 4. Expeditions table (references users)
                 result5 = await conn.execute('DELETE FROM expeditions')
-                
+
                 # 5. Users table last (root table)
                 result6 = await conn.execute('DELETE FROM users')
-                
+
                 # Parse the result strings to get the count of deleted rows
                 def parse_delete_result(result):
                     if result:
@@ -768,16 +773,16 @@ class Database:
                         except (ValueError, IndexError):
                             return 0
                     return 0
-                
-                deleted_count = (parse_delete_result(result1) + parse_delete_result(result2) + 
-                               parse_delete_result(result3) + parse_delete_result(result4) + 
+
+                deleted_count = (parse_delete_result(result1) + parse_delete_result(result2) +
+                               parse_delete_result(result3) + parse_delete_result(result4) +
                                parse_delete_result(result5) + parse_delete_result(result6))
-                
-                await self._log_operation("delete_all", "all_tables", start_time, success=True, 
+
+                await self._log_operation("delete_all", "all_tables", start_time, success=True,
                                         deleted_count=deleted_count)
                 return deleted_count
             except Exception as e:
-                await self._log_operation("delete_all", "all_tables", start_time, success=False, 
+                await self._log_operation("delete_all", "all_tables", start_time, success=False,
                                         error=str(e))
                 raise e
 
@@ -793,7 +798,7 @@ class Database:
                     WHERE d.paid = FALSE
                     ORDER BY d.created_at ASC
                 ''')
-                
+
                 deposits = []
                 for row in rows:
                     deposits.append({
@@ -808,12 +813,12 @@ class Database:
                         'paid_at': row[8] if len(row) > 8 else (row[6] if len(row) > 6 else None),
                         'total_melange': row[9] if len(row) > 9 else 0
                     })
-                
-                await self._log_operation("select_join", "deposits_users", start_time, success=True, 
+
+                await self._log_operation("select_join", "deposits_users", start_time, success=True,
                                         result_count=len(deposits))
                 return deposits
             except Exception as e:
-                await self._log_operation("select_join", "deposits_users", start_time, success=False, 
+                await self._log_operation("select_join", "deposits_users", start_time, success=False,
                                         error=str(e))
 
                 raise e

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,7 +48,7 @@ class TestHelpers:
 
         # Test Landsraad bonus rate
         rate = get_sand_per_melange(landsraad_bonus=True)
-        assert rate == 37
+        assert rate == 37.5
     
     @pytest.mark.asyncio
     async def test_send_response_interaction(self, mock_interaction):

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -22,7 +22,7 @@ def get_sand_per_melange(landsraad_bonus: bool = False) -> float:
     """
     Get the spice sand to melange conversion rate.
     - Default rate: 50 sand per melange
-    - Landsraad bonus rate: 37 sand per melange
+    - Landsraad bonus rate: 37.5 sand per melange
     """
     LANDSRAAD_BONUS_RATE = 37.5
     if landsraad_bonus:


### PR DESCRIPTION
The guild_withdraw command was erroring out. This commit fixes the command to use 'melange' instead of 'sand', correctly updates the user and guild balances, and resolves a follow-up bug in the database logging.

The guild_withdraw command now correctly withdraws 'melange' from the guild treasury and adds it to the user's total_melange.
All user-facing text for the command has been updated to refer to 'melange'.
A bug in the _log_operation call within guild_withdraw has been fixed, resolving a TypeError.
The get_sand_per_melange function in utils/helpers.py has been corrected to return 37.5 as a float, and its corresponding test and docstring have been updated to match, per user feedback.