### PR TITLE
fix(embeds): Allow color override in build_info_embed

### DIFF
--- a/utils/embed_utils.py
+++ b/utils/embed_utils.py
@@ -49,12 +49,12 @@ def build_success_embed(title: str, success_message: str, footer: str = None,
 
 
 def build_info_embed(title: str, info_message: str, footer: str = None, 
-                    timestamp=None) -> EmbedBuilder:
+                    timestamp=None, color: int = 0x3498DB) -> EmbedBuilder:
     """Build a standardized info embed"""
     return build_status_embed(
         title=title,
         description=info_message,
-        color=0x3498DB,
+        color=color,
         footer=footer,
         timestamp=timestamp
     )


### PR DESCRIPTION
The `build_info_embed` function was being called with a `color` argument from the refinery command, but the function did not accept this argument. This caused an error for users who had not yet produced any melange.

This change modifies the `build_info_embed` function to accept an optional `color` argument, which is then passed to the underlying `build_status_embed` function. This allows the color of the info embed to be customized while maintaining the default blue color for other uses.