### PR TITLE
Feat: Add pagination and melange to /ledger command

### DIFF
--- a/commands/ledger.py
+++ b/commands/ledger.py
@@ -90,23 +90,21 @@ class LedgerView(discord.ui.View):
         """Update the message with the new page."""
         embed, self.total_pages, _, _ = await build_ledger_embed(self.interaction, self.user_id, self.current_page)
         self.update_buttons()
-        await interaction.response.edit_message(embed=embed.build(), view=self)
+        await interaction.edit_original_response(embed=embed.build(), view=self)
 
     @discord.ui.button(label="Previous", style=discord.ButtonStyle.grey)
     async def previous_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
         if self.current_page > 1:
             self.current_page -= 1
             await self.update_message(interaction)
-        else:
-            await interaction.response.defer()
 
     @discord.ui.button(label="Next", style=discord.ButtonStyle.grey)
     async def next_button(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await interaction.response.defer()
         if self.current_page < self.total_pages:
             self.current_page += 1
             await self.update_message(interaction)
-        else:
-            await interaction.response.defer()
 
 @handle_interaction_expiration
 async def ledger(interaction, use_followup: bool = True):

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -13,6 +13,7 @@ def mock_interaction():
     interaction.created_at = datetime.now()
     interaction.response = AsyncMock()
     interaction.followup = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
     return interaction
 
 @pytest.fixture
@@ -77,7 +78,7 @@ async def test_ledger_pagination(mock_get_database, mock_interaction, mock_db):
     await view.next_button.callback(mock_interaction)
 
     # Check that the embed was updated to page 2
-    kwargs = mock_interaction.response.edit_message.call_args.kwargs
+    kwargs = mock_interaction.edit_original_response.call_args.kwargs
     embed = kwargs["embed"]
     assert "Page 2 of 3" in embed.footer.text
 
@@ -85,7 +86,7 @@ async def test_ledger_pagination(mock_get_database, mock_interaction, mock_db):
     await view.previous_button.callback(mock_interaction)
 
     # Check that the embed was updated back to page 1
-    kwargs = mock_interaction.response.edit_message.call_args.kwargs
+    kwargs = mock_interaction.edit_original_response.call_args.kwargs
     embed = kwargs["embed"]
     assert "Page 1 of 3" in embed.footer.text
 


### PR DESCRIPTION
This commit introduces pagination to the `/ledger` command to improve performance for users with a large number of deposits.

Key changes:
- Implemented a paginated view using `discord.ui.View`.
- Modified the database to fetch deposits in a paginated way.
- Added the calculated melange amount to each ledger entry.
- Added unit tests to verify the new functionality.
- Updated the `send_response` helper to support views.
- Made the `sand_per_melange` setting lookup more robust.
- Re-introduced detailed performance logging.
- Consolidated the `SAND_PER_MELANGE` constant.
- Fixed interaction timeouts in the pagination view.
- Refactored tests to use static mock data.
- Fixed a bug where `total_melange` was logged incorrectly for users with no deposits.