### PR TITLE
Feat: Add pagination and melange to /ledger command

### DIFF
--- a/supabase/migrations/20250910121128_add_composite_index_to_deposits.sql
+++ b/supabase/migrations/20250910121128_add_composite_index_to_deposits.sql
@@ -1,0 +1,2 @@
+-- Add a composite index to the deposits table to improve query performance for the ledger command.
+CREATE INDEX idx_deposits_user_id_created_at ON deposits (user_id, created_at DESC);


### PR DESCRIPTION
This commit introduces pagination to the `/ledger` command to improve performance for users with a large number of deposits.

Key changes:
- Implemented a paginated view using `discord.ui.View`.
- Modified the database to fetch deposits in a paginated way.
- Added the calculated melange amount to each ledger entry.
- Added unit tests to verify the new functionality.
- Updated the `send_response` helper to support views.
- Made the `sand_per_melange` setting lookup more robust.
- Re-introduced detailed performance logging.
- Consolidated the `SAND_PER_MELANGE` constant.
- Fixed interaction timeouts in the pagination view.
- Refactored tests to use static mock data.
- Fixed a bug where `total_melange` was logged incorrectly for users with no deposits.
- Added a composite index to the deposits table to improve query performance.
- Optimized data fetching in the ledger command to reduce database calls on pagination.