### PR TITLE
feat: Implement paginated ledger command

### DIFF
--- a/alembic/versions/a1db1fd306c3_add_melange_and_conversion_rate_to_.py
+++ b/alembic/versions/a1db1fd306c3_add_melange_and_conversion_rate_to_.py
@@ -1,0 +1,21 @@
+"""add melange and conversion rate to deposits
+Revision ID: a1db1fd306c3
+Revises: a6fe5e68863a
+Create Date: 2025-09-15 17:33:59.602297
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+# revision identifiers, used by Alembic.
+revision: str = 'a1db1fd306c3'
+down_revision: Union[str, Sequence[str], None] = 'a6fe5e68863a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('deposits', sa.Column('melange_amount', sa.Float(), nullable=True))
+    op.add_column('deposits', sa.Column('conversion_rate', sa.Float(), nullable=True))
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('deposits', 'conversion_rate')
+    op.drop_column('deposits', 'melange_amount')

--- a/commands/backfill.py
+++ b/commands/backfill.py
@@ -1,0 +1,54 @@
+"""
+Backfill command for data migration tasks.
+"""
+
+# Command metadata
+COMMAND_METADATA = {
+    'aliases': [],
+    'description': "Perform data backfill operations (admin only)",
+    'permission_level': 'admin'
+}
+
+import time
+from utils.database_utils import timed_database_operation
+from utils.embed_utils import build_status_embed
+from utils.base_command import command
+from utils.helpers import get_database, send_response
+from sqlalchemy import select, update
+from database_orm import Deposit
+
+@command('backfill')
+async def backfill(interaction, command_start, use_followup: bool = True):
+    """Perform data backfill operations."""
+
+    db = get_database()
+    async with db._get_session() as session:
+        # Find deposits that need backfill
+        stmt = select(Deposit).where(Deposit.melange_amount.is_(None))
+        result = await session.execute(stmt)
+        deposits_to_update = result.scalars().all()
+
+        if not deposits_to_update:
+            await send_response(interaction, "✅ No deposits to backfill.", use_followup=use_followup, ephemeral=True)
+            return
+
+        updated_count = 0
+        default_conversion_rate = 50.0
+        for deposit in deposits_to_update:
+            melange_amount = deposit.sand_amount / default_conversion_rate
+            update_stmt = (
+                update(Deposit)
+                .where(Deposit.id == deposit.id)
+                .values(melange_amount=melange_amount, conversion_rate=default_conversion_rate)
+            )
+            await session.execute(update_stmt)
+            updated_count += 1
+
+        await session.commit()
+
+    embed = build_status_embed(
+        title="📈 Backfill Complete",
+        description=f"Updated **{updated_count}** deposit records with calculated melange amounts.",
+        color=0x2ECC71
+    )
+    await send_response(interaction, embed=embed.build(), use_followup=use_followup, ephemeral=True)

--- a/database_orm.py
+++ b/database_orm.py
@@ -58,6 +58,8 @@ class Deposit(Base):
     sand_amount: Mapped[int] = mapped_column(Integer, nullable=False)
     type: Mapped[str] = mapped_column(String(20), default="solo")
     expedition_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("expeditions.id"))
+    melange_amount: Mapped[Optional[float]] = mapped_column(Float)
+    conversion_rate: Mapped[Optional[float]] = mapped_column(Float)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.utcnow())
 
     # Relationships
@@ -386,7 +388,7 @@ class Database:
                 await self._log_operation("upsert", "users", start_time, success=False, user_id=user_id, username=username, error=str(e))
                 raise e
 
-    async def add_deposit(self, user_id: str, username: str, sand_amount: int, deposit_type: str = 'solo', expedition_id: Optional[int] = None):
+    async def add_deposit(self, user_id: str, username: str, sand_amount: int, deposit_type: str = 'solo', expedition_id: Optional[int] = None, melange_amount: Optional[float] = None, conversion_rate: Optional[float] = None):
         """Add a new sand deposit for a user"""
         start_time = time.time()
         async with self._get_session() as session:
@@ -400,7 +402,9 @@ class Database:
                     username=username,
                     sand_amount=sand_amount,
                     type=deposit_type,
-                    expedition_id=expedition_id
+                    expedition_id=expedition_id,
+                    melange_amount=melange_amount,
+                    conversion_rate=conversion_rate
                 )
                 session.add(deposit)
                 await session.commit()
@@ -412,14 +416,20 @@ class Database:
                                         user_id=user_id, sand_amount=sand_amount, deposit_type=deposit_type, expedition_id=expedition_id, error=str(e))
                 raise e
 
-    async def get_user_deposits(self, user_id: str) -> List[Dict[str, Any]]:
-        """Get all deposits for a user"""
+    async def get_user_deposits(self, user_id: str, page: int = 1, per_page: int = 10) -> List[Dict[str, Any]]:
+        """Get a paginated list of deposits for a user."""
         start_time = time.time()
         async with self._get_session() as session:
             try:
-                result = await session.execute(
-                    select(Deposit).where(Deposit.user_id == user_id).order_by(Deposit.created_at.desc())
+                offset = (page - 1) * per_page
+                query = (
+                    select(Deposit)
+                    .where(Deposit.user_id == user_id)
+                    .order_by(Deposit.created_at.desc())
+                    .offset(offset)
+                    .limit(per_page)
                 )
+                result = await session.execute(query)
                 deposits = result.scalars().all()
 
                 deposit_list = []
@@ -429,6 +439,8 @@ class Database:
                         'user_id': deposit.user_id,
                         'username': deposit.username,
                         'sand_amount': deposit.sand_amount,
+                        'melange_amount': deposit.melange_amount,
+                        'conversion_rate': deposit.conversion_rate,
                         'type': deposit.type,
                         'expedition_id': deposit.expedition_id,
                         'created_at': deposit.created_at
@@ -440,6 +452,20 @@ class Database:
             except Exception as e:
                 await self._log_operation("select", "deposits", start_time, success=False,
                                         user_id=user_id, error=str(e))
+                raise e
+
+    async def get_user_deposits_count(self, user_id: str) -> int:
+        """Get the total number of deposits for a user."""
+        start_time = time.time()
+        async with self._get_session() as session:
+            try:
+                query = select(func.count()).select_from(Deposit).where(Deposit.user_id == user_id)
+                result = await session.execute(query)
+                count = result.scalar_one()
+                await self._log_operation("count", "deposits", start_time, success=True, user_id=user_id, count=count)
+                return count
+            except Exception as e:
+                await self._log_operation("count", "deposits", start_time, success=False, user_id=user_id, error=str(e))
                 raise e
 
     async def create_expedition(self, initiator_id: str, initiator_username: str, total_sand: int,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -52,7 +52,8 @@ class TestCommandDiscovery:
         expected_commands = {
             'sand', 'refinery', 'leaderboard',
             'split', 'help', 'reset', 'ledger', 'expedition',
-            'pay', 'payroll', 'treasury', 'guild_withdraw', 'pending', 'water', 'landsraad', 'perms', 'calc'
+            'pay', 'payroll', 'treasury', 'guild_withdraw', 'pending', 'water', 'landsraad', 'perms', 'calc',
+            'backfill'
         }
 
         discovered_commands = set(COMMAND_METADATA.keys())

--- a/tests/test_ledger_command.py
+++ b/tests/test_ledger_command.py
@@ -1,0 +1,103 @@
+"""
+Tests for the ledger command.
+"""
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+
+from commands.ledger import ledger, LedgerView
+from utils.helpers import get_database
+
+class TestLedgerCommand:
+    """Test the ledger command."""
+
+    @pytest.mark.asyncio
+    async def test_ledger_no_deposits(self, mock_interaction):
+        """Test ledger command for a user with no deposits."""
+        mock_interaction.created_at = datetime.now()
+        mock_db = AsyncMock()
+        mock_db.get_user_deposits_count.return_value = 0
+        mock_db.get_user.return_value = {
+            'user_id': '123',
+            'username': 'TestUser',
+            'total_melange': 0,
+            'paid_melange': 0
+        }
+
+        with patch('commands.ledger.get_database', return_value=mock_db):
+            # The decorator will provide command_start, and the test harness provides use_followup
+            await ledger(mock_interaction)
+
+        mock_interaction.followup.send.assert_called_once()
+        sent_embed = mock_interaction.followup.send.call_args[1]['embed']
+        assert "You haven't made any melange yet!" in sent_embed.description
+
+    @pytest.mark.asyncio
+    async def test_ledger_with_deposits_sends_view(self, mock_interaction):
+        """Test that the ledger command sends a view when there are deposits."""
+        mock_interaction.created_at = datetime.now()
+        mock_db = AsyncMock()
+        mock_db.get_user_deposits_count.return_value = 15
+        mock_db.get_user_deposits.return_value = [{'sand_amount': 100, 'created_at': datetime.now(), 'type': 'solo', 'melange_amount': 2.0}]
+        mock_db.get_user.return_value = {
+            'user_id': '123',
+            'username': 'TestUser',
+            'total_melange': 100,
+            'paid_melange': 50
+        }
+
+        with patch('commands.ledger.get_database', return_value=mock_db):
+            await ledger(mock_interaction)
+
+        mock_interaction.followup.send.assert_called_once()
+        sent_view = mock_interaction.followup.send.call_args[1]['view']
+        assert isinstance(sent_view, LedgerView)
+        assert sent_view.total_pages == 2
+
+    @pytest.mark.asyncio
+    async def test_ledger_view_pagination(self, mock_interaction):
+        """Test the pagination logic of the LedgerView."""
+        mock_interaction.created_at = datetime.now()
+        user = {
+            'user_id': '123',
+            'username': 'TestUser',
+            'total_melange': 100,
+            'paid_melange': 50
+        }
+        view = LedgerView(mock_interaction, user, 25) # 3 pages
+
+        # Mock the database for the view
+        mock_db = AsyncMock()
+        mock_db.get_user_deposits.return_value = [{'sand_amount': 100, 'created_at': datetime.now(), 'type': 'solo', 'melange_amount': 2.0}]
+
+        with patch('commands.ledger.get_database', return_value=mock_db):
+            # Initial state
+            assert view.current_page == 1
+
+            # Simulate the initial interaction response
+            mock_interaction.response.edit_message = AsyncMock()
+
+            # Go to next page
+            await view.next_button.callback(mock_interaction)
+            assert view.current_page == 2
+            mock_interaction.response.edit_message.assert_called_once()
+
+            # Go to last page by manually setting page number
+            view.current_page = 3
+            await view.update_view(mock_interaction)
+            assert view.next_button.disabled
+
+            # Go to previous page
+            await view.previous_button.callback(mock_interaction)
+            assert view.current_page == 2
+            assert not view.next_button.disabled
+            assert not view.previous_button.disabled
+
+    @pytest.mark.asyncio
+    async def test_ledger_view_timeout(self):
+        """Test that the view buttons are disabled on timeout."""
+        view = LedgerView(MagicMock(), {}, 1)
+        await view.on_timeout()
+        assert view.previous_button.disabled
+        assert view.next_button.disabled

--- a/tests/test_orm_database.py
+++ b/tests/test_orm_database.py
@@ -189,3 +189,48 @@ class TestORMDatabase:
         user = await test_database.get_user(user_id)
         assert user is not None
         assert user['username'] == username
+
+
+class TestPaginatedDepositOperations:
+    """Test paginated deposit operations."""
+
+    @pytest.fixture(scope="function")
+    async def setup_deposits(self, test_database):
+        """Setup a user with many deposits for pagination tests."""
+        user_id = "pagination_user"
+        username = "PaginationUser"
+        await test_database.upsert_user(user_id, username)
+        for i in range(25):
+            await test_database.add_deposit(user_id, username, 100 + i, melange_amount=2.0, conversion_rate=50.0)
+        return user_id
+
+    @pytest.mark.asyncio
+    async def test_get_user_deposits_count(self, test_database, setup_deposits):
+        """Test counting user deposits."""
+        user_id = await setup_deposits
+        count = await test_database.get_user_deposits_count(user_id)
+        assert count == 25
+
+    @pytest.mark.asyncio
+    async def test_get_user_deposits_pagination(self, test_database, setup_deposits):
+        """Test paginated fetching of user deposits."""
+        user_id = await setup_deposits
+
+        # Test first page
+        page1 = await test_database.get_user_deposits(user_id, page=1, per_page=10)
+        assert len(page1) == 10
+        assert page1[0]['sand_amount'] == 124 # Most recent deposit
+
+        # Test second page
+        page2 = await test_database.get_user_deposits(user_id, page=2, per_page=10)
+        assert len(page2) == 10
+        assert page2[0]['sand_amount'] == 114
+
+        # Test last page
+        page3 = await test_database.get_user_deposits(user_id, page=3, per_page=10)
+        assert len(page3) == 5
+        assert page3[0]['sand_amount'] == 104
+
+        # Test out of bounds page
+        page4 = await test_database.get_user_deposits(user_id, page=4, per_page=10)
+        assert len(page4) == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,17 +49,17 @@ class TestHelpers:
     @pytest.mark.asyncio
     async def test_send_response_interaction(self, mock_interaction):
         """Test send_response with interaction."""
-        await send_response(mock_interaction, "Test message", use_followup=False)
+        await send_response(mock_interaction, content="Test message", use_followup=False)
         
         # When use_followup=False, it calls channel.send, not response.send
-        mock_interaction.channel.send.assert_called_once_with("Test message")
+        mock_interaction.channel.send.assert_called_once_with(content="Test message")
     
     @pytest.mark.asyncio
     async def test_send_response_followup(self, mock_interaction):
         """Test send_response with followup."""
-        await send_response(mock_interaction, "Test message", use_followup=True)
+        await send_response(mock_interaction, content="Test message", use_followup=True, ephemeral=True)
         
-        mock_interaction.followup.send.assert_called_once_with("Test message", ephemeral=False)
+        mock_interaction.followup.send.assert_called_once_with(content="Test message", ephemeral=True)
     
     @pytest.mark.asyncio
     async def test_send_response_with_embed(self, mock_interaction):


### PR DESCRIPTION
This commit refactors the ledger command to use a paginated view, improving performance and user experience.

Key changes:
- Adds `melange_amount` and `conversion_rate` to the `deposits` table to store historical conversion data.
- Creates an alembic migration for the schema changes.
- Adds a `backfill.py` command to populate historical data.
- Implements a `discord.ui.View` for pagination in the ledger command.
- Updates database functions to support paginated fetching of deposits.
- Updates the `send_response` helper to support views.
- Fixes a bug where metrics were not logged for users with no deposits.
- Adds comprehensive unit tests for the new functionality.