### PR TITLE
feat: Implement paginated ledger command

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -62,8 +62,11 @@ def run_migrations_online() -> None:
     """
     # Override the database URL with environment variable
     configuration = config.get_section(config.config_ini_section, {})
-    if 'DATABASE_URL' in os.environ:
-        configuration['sqlalchemy.url'] = os.environ['DATABASE_URL']
+    db_url = os.environ.get('DATABASE_URL')
+    if db_url:
+        # Alembic needs a sync driver
+        sync_db_url = db_url.replace("postgresql+asyncpg", "postgresql+psycopg2")
+        configuration['sqlalchemy.url'] = sync_db_url
     else:
         # Fallback to a default SQLite URL for development
         configuration['sqlalchemy.url'] = 'sqlite:///spice_tracker.db'


### PR DESCRIPTION
This commit refactors the ledger command to use a paginated view, improving performance and user experience.

Key changes:
- Adds `melange_amount` and `conversion_rate` to the `deposits` table to store historical conversion data.
- Creates an alembic migration for the schema changes.
- Adds a `backfill.py` command to populate historical data.
- Implements a `discord.ui.View` for pagination in the ledger command.
- Updates database functions to support paginated fetching of deposits.
- Updates the `send_response` helper to support views.
- Fixes a bug where metrics were not logged for users with no deposits.
- Adds comprehensive unit tests for the new functionality.

fix: Use synchronous driver for Alembic migrations