### PR TITLE
fix(split, ledger): Correct guild cut, deposit recording, and display

### DIFF
--- a/commands/split.py
+++ b/commands/split.py
@@ -121,7 +121,8 @@ async def split(interaction, command_start, total_sand: int, users: str, guild: 
         # Calculate remaining melange that goes to guild
         total_user_melange = sum(melange for melange, _ in unique_distributions.values())
         guild_melange = total_melange - total_user_melange
-        guild_sand = remaining_sand  # Any leftover sand also goes to guild
+        guild_sand_from_melange = int(guild_melange * conversion_rate)
+        guild_sand = guild_sand_from_melange + remaining_sand
 
         # Ensure the initiator exists in the users table
         from utils.database_utils import validate_user_exists


### PR DESCRIPTION
This commit addresses several issues with the /split and /ledger commands:

1.  The `/split` command was not applying the guild cut correctly. It now calculates the guild cut from the total melange before distributing the rest to players.
2.  The `/split` command's summary message was showing "0 sand" for the guild cut. It now correctly calculates the sand equivalent of the guild's melange.
3.  The `/split` command was not correctly recording group deposits. It now passes `deposit_type='group'`, `melange_amount`, and `conversion_rate` to the `add_deposit` function.
4.  The `/ledger` command had display issues. It now correctly displays the deposit type for 'group' deposits, and it formats melange amounts to remove trailing `.00` for whole numbers.