### PR TITLE
feat: Implement guild_withdraw command for melange

### DIFF
--- a/commands/guild_withdraw.py
+++ b/commands/guild_withdraw.py
@@ -1,14 +1,14 @@
 """
-Guild Withdraw command for transferring sand from guild treasury to users (Admin only).
+Guild Withdraw command for transferring melange from guild treasury to users (Admin only).
 """
 
 # Command metadata
 COMMAND_METADATA = {
-    'aliases': [],  # ['withdraw'] - removed for simplicity
-    'description': "Withdraw sand from guild treasury to give to a user (Admin/Officer only)",
+    'aliases': [],  # ['gwithdraw']
+    'description': "Withdraw melange from guild treasury to give to a user (Admin/Officer only)",
     'params': {
-        'user': "User to give sand to",
-        'amount': "Amount of sand to withdraw from guild treasury"
+        'user': "User to give melange to",
+        'amount': "Amount of melange to withdraw from guild treasury"
     },
     'permission_level': 'admin_or_officer'
 }
@@ -25,12 +25,12 @@ from utils.logger import logger
 
 @admin_command('guild_withdraw')
 async def guild_withdraw(interaction, command_start, user: discord.Member, amount: int, use_followup: bool = True):
-    """Withdraw sand from guild treasury and give to a user (Admin only)"""
+    """Withdraw melange from guild treasury and give to a user (Admin only)"""
 
     try:
         # Validate amount
         if amount < 1:
-            await send_response(interaction, "❌ Withdrawal amount must be at least 1 sand.", use_followup=use_followup, ephemeral=True)
+            await send_response(interaction, "❌ Withdrawal amount must be at least 1 melange.", use_followup=use_followup, ephemeral=True)
             return
 
         # Get current guild treasury balance
@@ -39,13 +39,13 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
             get_database().get_guild_treasury
         )
 
-        current_sand = treasury_data.get('total_sand', 0)
-        if current_sand < amount:
+        current_melange = treasury_data.get('total_melange', 0)
+        if current_melange < amount:
             await send_response(interaction,
                 f"❌ Insufficient guild treasury funds.\n\n"
-                f"**Available:** {current_sand:,} sand\n"
-                f"**Requested:** {amount:,} sand\n"
-                f"**Shortfall:** {amount - current_sand:,} sand",
+                f"**Available:** {current_melange:,.2f} melange\n"
+                f"**Requested:** {amount:,.2f} melange\n"
+                f"**Shortfall:** {amount - current_melange:,.2f} melange",
                 use_followup=use_followup, ephemeral=True)
             return
 
@@ -65,13 +65,13 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
 
         # Build response embed
         fields = {
-            "💸 Transaction": f"**Recipient:** {user.display_name} | **Amount:** {amount:,} sand | **Admin:** {interaction.user.display_name}",
-            "🏛️ Treasury": f"**Previous:** {current_sand:,} | **New:** {updated_treasury.get('total_sand', 0):,} | **Available:** {updated_treasury.get('total_sand', 0):,}"
+            "💸 Transaction": f"**Recipient:** {user.display_name} | **Amount:** {amount:,.2f} melange | **Admin:** {interaction.user.display_name}",
+            "🏛️ Treasury": f"**Previous:** {current_melange:,.2f} | **New:** {updated_treasury.get('total_melange', 0):,.2f} | **Available:** {updated_treasury.get('total_melange', 0):,.2f}"
         }
 
         embed = build_status_embed(
             title="✅ Guild Withdrawal Completed",
-            description=f"💰 **{amount:,} sand** transferred from guild treasury to **{user.display_name}**",
+            description=f"💰 **{amount:,.2f} melange** transferred from guild treasury to **{user.display_name}**",
             color=0x00FF00,
             fields=fields,
             timestamp=interaction.created_at
@@ -97,12 +97,12 @@ async def guild_withdraw(interaction, command_start, user: discord.Member, amoun
             withdraw_time=f"{withdraw_time:.3f}s",
             response_time=f"{response_time:.3f}s",
             withdrawal_amount=amount,
-            previous_balance=current_sand,
-            new_balance=updated_treasury.get('total_sand', 0)
+            previous_balance=current_melange,
+            new_balance=updated_treasury.get('total_melange', 0)
         )
 
         # Log the withdrawal for audit
-        logger.info(f"Guild withdrawal: {amount:,} sand from treasury to {user.display_name} ({user.id}) by {interaction.user.display_name} ({interaction.user.id})")
+        logger.info(f"Guild withdrawal: {amount:,.2f} melange from treasury to {user.display_name} ({user.id}) by {interaction.user.display_name} ({interaction.user.id})")
 
     except ValueError as ve:
         # Handle insufficient funds or other validation errors


### PR DESCRIPTION
Implements the `guild_withdraw` command to allow admins to withdraw melange from the guild treasury and grant it to a user.

The changes include:
- A new `guild_withdraw` method in `database_orm.py` that atomically handles the withdrawal logic.
- Updates the user's total melange in the `users` table.
- Logs the withdrawal in the `guild_transactions` table.
- Creates a corresponding entry in the `deposits` table with type "Guild" and sand set to 0.
- Updates the command in `commands/guild_withdraw.py` to use the new database method and reflect that the currency is melange, not sand.