### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI Pipeline
 
 permissions:
+  security-events: write
+  packages: read
+  actions: read
   contents: read
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/sininspira2/spice-tracker-bot-tma/security/code-scanning/1](https://github.com/sininspira2/spice-tracker-bot-tma/security/code-scanning/1)

To fix the issue, you should add an explicit `permissions` block specifying the minimal permissions required for all jobs (unless a job has its own `permissions` key). The recommendation is to set `contents: read` at the workflow level, which applies to all jobs. If a particular job (e.g., `deploy`) needs more permissions (such as write access for deployments or manipulating pull requests), you may set broader permissions **for that job only**. Based on the provided workflow, none of the jobs seem to need write access except potentially for deployment (if, for example, writing artifacts or interacting with repository content is required). As a starting point, add the following at the top level of the workflow (below `name: CI Pipeline` and before or after `on:`):

```yaml
permissions:
  contents: read
```

This ensures best-practice "least privilege" for GITHUB_TOKEN usage throughout the workflow.

**Required changes:**
- File: `.github/workflows/ci.yml`
  - Insert the block `permissions: contents: read` after line 1 or before line 8.
- No imports or additional dependencies required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
