### PR TITLE
feat: Add confirmation steps to payroll and reset commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -234,8 +234,9 @@ def register_commands():
 
     # Payroll command
     @bot.tree.command(name=cmd_name("payroll"), description="Process payments for all unpaid harvesters (Admin only)")
-    async def payroll_cmd(interaction: discord.Interaction):  # noqa: F841
-        await payroll(interaction)
+    @app_commands.describe(confirm="Confirm that you want to run payroll (True/False)")
+    async def payroll_cmd(interaction: discord.Interaction, confirm: bool):  # noqa: F841
+        await payroll(interaction, confirm)
 
     # Pending command
     @bot.tree.command(name=cmd_name("pending"), description="View all users with pending melange payments (Admin only)")


### PR DESCRIPTION
This commit introduces confirmation steps for the `/payroll` and `/reset` administrative commands to prevent accidental data loss.

The `/payroll` command now includes a required `confirm: True` boolean parameter. The command will only proceed if this parameter is provided and set to `True`. The command registration in `bot.py` has been updated to reflect this new required parameter.

The `/reset` command now has a two-step confirmation process. It first requires a `confirm: True` parameter. If confirmed, it then presents the administrator with a secondary confirmation message containing "Confirm" and "Cancel" buttons. The irreversible data reset will only occur if the "Confirm" button is clicked.

A reusable `ConfirmView` class has been added to the `views/` directory to handle the button-based confirmation logic. The view now defers the interaction by calling `interaction.response.defer()` to prevent timeouts on potentially long-running operations.

All relevant tests have been updated to account for these new confirmation flows, including new targeted tests for these features and smoke tests for other commands to ensure continued coverage. The test suite now passes.