### PR TITLE
feat: Add confirmation steps to payroll and reset commands

### DIFF
--- a/commands/payroll.py
+++ b/commands/payroll.py
@@ -62,8 +62,8 @@ async def payroll(interaction, command_start, confirm: bool, use_followup: bool 
     if paid_users:
         paid_users_list = [f"**{user['username']}**: {user['amount_paid']:,} melange" for user in paid_users]
         paid_users_str = "\n".join(paid_users_list)
-        if len(paid_users_str) > 1024:
-            paid_users_str = paid_users_str[:1020] + "\n..."
+        if len(paid_users_str) > 1024:  # Discord embed field value limit
+            paid_users_str = paid_users_str[:1024 - 4] + "\n..."
         fields["💸 Paid Users"] = paid_users_str
 
 

--- a/commands/payroll.py
+++ b/commands/payroll.py
@@ -42,6 +42,7 @@ async def payroll(interaction, command_start, confirm: bool, use_followup: bool 
 
     total_paid = payroll_result.get('total_paid', 0)
     users_paid = payroll_result.get('users_paid', 0)
+    paid_users = payroll_result.get('paid_users', [])
 
     if users_paid == 0:
         embed = build_status_embed(
@@ -57,6 +58,14 @@ async def payroll(interaction, command_start, confirm: bool, use_followup: bool 
     fields = {
         "💰 Payroll Summary": f"**Melange Paid:** {total_paid:,} | **Users Paid:** {users_paid} | **Admin:** {interaction.user.display_name}"
     }
+
+    if paid_users:
+        paid_users_list = [f"**{user['username']}**: {user['amount_paid']:,} melange" for user in paid_users]
+        paid_users_str = "\n".join(paid_users_list)
+        if len(paid_users_str) > 1024:
+            paid_users_str = paid_users_str[:1020] + "\n..."
+        fields["💸 Paid Users"] = paid_users_str
+
 
     embed = build_status_embed(
         title="💰 Guild Payroll Complete",

--- a/database_orm.py
+++ b/database_orm.py
@@ -943,31 +943,6 @@ class Database:
         try:
             count = 0
             total_paid = 0
-            async with self.transaction() as session:
-                # Get all users
-                result = await session.execute(select(User))
-                users = result.scalars().all()
-
-                for user in users:
-                    pending = user.total_melange - user.paid_melange
-                    if pending > 0:
-                        # Update user's paid melange
-                        user.paid_melange += pending
-
-                        # Record the payment
-                        payment = MelangePayment(
-                            user_id=user.user_id,
-                            username=user.username,
-                            melange_amount=pending,
-                            admin_user_id=admin_user_id,
-                            admin_username=admin_username,
-                            description=f"Bulk payment of {pending} melange"
-                        )
-                        session.add(payment)
-
-                        count += 1
-                        total_paid += pending
-
             paid_users_details = []
             async with self.transaction() as session:
                 # Get all users

--- a/database_orm.py
+++ b/database_orm.py
@@ -968,9 +968,36 @@ class Database:
                         count += 1
                         total_paid += pending
 
+            paid_users_details = []
+            async with self.transaction() as session:
+                # Get all users
+                result = await session.execute(select(User))
+                users = result.scalars().all()
+
+                for user in users:
+                    pending = user.total_melange - user.paid_melange
+                    if pending > 0:
+                        # Update user's paid melange
+                        user.paid_melange += pending
+
+                        # Record the payment
+                        payment = MelangePayment(
+                            user_id=user.user_id,
+                            username=user.username,
+                            melange_amount=pending,
+                            admin_user_id=admin_user_id,
+                            admin_username=admin_username,
+                            description=f"Bulk payment of {pending} melange"
+                        )
+                        session.add(payment)
+
+                        count += 1
+                        total_paid += pending
+                        paid_users_details.append({'username': user.username, 'amount_paid': pending})
+
             await self._log_operation("update", "users", start_time, success=True,
                                     count=count, total_paid=total_paid)
-            return {'total_paid': total_paid, 'users_paid': count}
+            return {'total_paid': total_paid, 'users_paid': count, 'paid_users': paid_users_details}
 
         except Exception as e:
             await self._log_operation("update", "users", start_time, success=False,


### PR DESCRIPTION
This commit introduces confirmation steps for the `/payroll` and `/reset` administrative commands to prevent accidental data loss.

The `/payroll` command now includes a required `confirm: True` boolean parameter. The command will only proceed if this parameter is provided and set to `True`. The command registration in `bot.py` has been updated to reflect this new required parameter. The payroll receipt embed now also includes a detailed list of users paid and the amounts they received.

The `/reset` command now has a two-step confirmation process. It first requires a `confirm: True` parameter. If confirmed, it then presents the administrator with a secondary confirmation message containing "Confirm" and "Cancel" buttons. The irreversible data reset will only occur if the "Confirm" button is clicked.

A reusable `ConfirmView` class has been added to the `views/` directory to handle the button-based confirmation logic. The view now defers the interaction by calling `interaction.response.defer()` to prevent timeouts on potentially long-running operations.

All relevant tests have been updated to account for these new confirmation flows, including new targeted tests for these features and smoke tests for other commands to ensure continued coverage. The test suite now passes.