### PR TITLE
feat: Implement database-backed role management commands

### DIFF
--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,6 +1,6 @@
 import pytest
 from unittest.mock import Mock, patch
-from utils.permissions import is_admin, is_officer, is_user, check_permission
+from utils.permissions import is_admin, is_officer, is_user, check_permission, _get_command_permission_level
 from utils.helpers import update_admin_roles, update_officer_roles, update_user_roles
 
 @pytest.fixture(autouse=True)
@@ -143,3 +143,23 @@ class TestPermissions:
         update_user_roles([])
         set_user_roles(mock_interaction, [401])
         assert check_permission(mock_interaction, "user") is True
+
+class TestCommandPermissionMapping:
+    @pytest.mark.parametrize("command_name, expected_level", [
+        # Admin commands
+        ("reset", "admin"),
+        ("pay", "admin"),
+        # User commands
+        ("sand", "user"),
+        ("split", "user"),
+        ("leaderboard", "user"),
+        # Any commands
+        ("help", "any"),
+        ("perms", "any"),
+        ("calc", "any"),
+        # Default case
+        ("some_unknown_command", "user"),
+    ])
+    def test_get_command_permission_level(self, command_name, expected_level):
+        """Tests the mapping of command names to permission levels."""
+        assert _get_command_permission_level(command_name) == expected_level

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -15,8 +15,8 @@ def _get_command_permission_level(command_name: str) -> str:
     """
     # Default permission levels for known commands
     admin_commands = {'reset', 'pending', 'payroll', 'pay', 'guild_withdraw'}
-    user_commands = {'sand', 'refinery', 'treasury', 'ledger', 'expedition', 'split', 'water'}
-    any_commands = {'help', 'leaderboard', 'perms', 'calc'}
+    user_commands = {'sand', 'refinery', 'treasury', 'ledger', 'expedition', 'split', 'water', 'leaderboard'}
+    any_commands = {'help', 'perms', 'calc'}
 
     if command_name in admin_commands:
         return 'admin'


### PR DESCRIPTION
Refactors the role management system to move from environment variables to new database-backed `/settings` subcommands. This allows server administrators to configure permissions dynamically without needing to restart the bot or modify deployment configurations.

The user with the `BOT_OWNER_ID` is now automatically granted admin privileges to ensure they can always manage permissions.

Key changes:
- Adds three new subcommands: `/settings admin_roles`, `/settings officer_roles`, and `/settings user_roles`.
- These commands support setting roles via comma-separated IDs or role mentions, and viewing the current configuration.
- Role settings are stored in the `global_settings` database table and cached in memory on bot startup for performance.
- The permission-checking functions (`is_admin`, `is_officer`, `is_user`) and the `/perms` command have been updated to use the new cached roles.
- The `is_admin` function now grants admin privileges to the `BOT_OWNER_ID`.
- Refactored permission-checking functions in `utils/permissions.py` to reduce code duplication by using a helper function.
- Refactored `parse_roles` in `utils/helpers.py` to be more concise.
- Adjusted command permission levels to correctly scope the `leaderboard` command to 'user' access.
- Adds a new test file `tests/test_permissions.py` for the permission logic and updates existing tests in `tests/test_settings_commands.py` and `tests/test_perms_command.py` to ensure full test coverage.