### PR TITLE
feat: Refactor help command with pagination and update all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python bot.py               # Start the bot
 #### User & Payroll Management
 - **`/pending`**: View a list of all users with pending (unpaid) melange.
 - **`/pay <user> [amount]`**: Pay a user their owed melange.
-- **`/payroll confirm:True`**: Initiate a payroll run to pay all users all their pending melange.
+- **`/payroll <confirm>`**: Initiate a payroll run to pay all users all their pending melange.
 
 #### Guild Management
 - **`/guild treasury`**: View the guild's current treasury balance.
@@ -144,13 +144,13 @@ python bot.py               # Start the bot
 
 #### Bot Settings
 - **`/settings [subcommand]`**: View a setting by running the subcommand without any options (e.g., `/settings admin_roles`).
-- **`/settings [admin_roles|officer_roles|user_roles] [roles]`**: Set or clear the roles that grant bot permissions.
+- **`/settings [roles]`**: Set or clear the roles that grant bot permissions.
 - **`/settings landsraad [action]`**: Manage the Landsraad conversion bonus (`status`, `enable`, `disable`).
-- **`/settings [user_cut|guild_cut] [value]`**: Configure the default user and guild cut percentages for `/split`.
+- **`/settings [cuts]`**: Configure the default user and guild cut percentages for `/split`.
 - **`/settings region [region]`**: Set the guild's primary operational region.
 
 #### System Commands
-- **`/reset confirm:True`**: **(Admin Only)** Reset all refinery and user data. This is irreversible.
+- **`/reset <confirm>`**: **(Admin Only)** Reset all refinery and user data. This is irreversible.
 - **`/sync`**: **(Bot Owner Only)** Manually sync application commands with Discord.
 
 ## 📊 How It Works

--- a/commands/help.py
+++ b/commands/help.py
@@ -26,7 +26,7 @@ PAGES_CONTENT = [
                 "commands": [
                     {"name": "/help", "desc": "Show this list of commands."},
                     {"name": "/perms", "desc": "Check your current permission level."},
-                    {"name": "/calc `[amount]`", "desc": "Estimate melange from sand without saving."},
+                    {"name": "/calc [amount]", "desc": "Estimate melange from sand without saving."},
                 ]
             }
         ]
@@ -39,13 +39,13 @@ PAGES_CONTENT = [
             {
                 "title": "",
                 "commands": [
-                    {"name": "/sand `[amount]`", "desc": "Convert your sand into melange."},
+                    {"name": "/sand [amount]", "desc": "Convert your sand into melange."},
                     {"name": "/refinery", "desc": "View your melange production and payment status."},
                     {"name": "/ledger", "desc": "View your personal conversion history."},
-                    {"name": "/leaderboard `[limit]`", "desc": "See the top melange producers."},
-                    {"name": "/split `[sand] [users]`", "desc": "Split sand with others and convert it to melange."},
-                    {"name": "/expedition `[id]`", "desc": "View the details of a specific split/expedition."},
-                    {"name": "/water `[destination]`", "desc": "Request a water delivery."},
+                    {"name": "/leaderboard [limit]", "desc": "See the top melange producers."},
+                    {"name": "/split [sand] [users]", "desc": "Split sand with others and convert it to melange."},
+                    {"name": "/expedition [id]", "desc": "View the details of a specific split/expedition."},
+                    {"name": "/water [destination]", "desc": "Request a water delivery."},
                 ]
             }
         ]
@@ -59,15 +59,15 @@ PAGES_CONTENT = [
                 "title": "User & Payroll Management",
                 "commands": [
                     {"name": "/pending", "desc": "View all users with pending (unpaid) melange."},
-                    {"name": "/pay `[user] [amount]`", "desc": "Pay a user their pending melange."},
-                    {"name": "/payroll `confirm:True`", "desc": "Pay all users with pending melange at once."},
+                    {"name": "/pay [user] [amount]", "desc": "Pay a user their pending melange."},
+                    {"name": "/payroll [confirm]", "desc": "Pay all users with pending melange at once."},
                 ]
             },
             {
                 "title": "Guild Management",
                 "commands": [
                     {"name": "/guild treasury", "desc": "View the guild's treasury balance."},
-                    {"name": "/guild withdraw `[user] [amount]`", "desc": "Withdraw melange from the treasury to a user."},
+                    {"name": "/guild withdraw [user] [amount]", "desc": "Withdraw melange from the treasury to a user."},
                     {"name": "/guild transactions", "desc": "View the guild's transaction history."},
                     {"name": "/guild payouts", "desc": "View the guild's melange payout history."},
                 ]
@@ -82,17 +82,17 @@ PAGES_CONTENT = [
             {
                 "title": "Bot Settings",
                 "commands": [
-                    {"name": "/settings `[subcommand]`", "desc": "View a setting by calling it without options."},
-                    {"name": "/settings `[roles]`", "desc": "Set or clear permission roles (e.g., `admin_roles`)."},
-                    {"name": "/settings landsraad `[action]`", "desc": "Manage the Landsraad conversion bonus."},
-                    {"name": "/settings `[cuts]`", "desc": "Set default percentages for `/split` (e.g., `user_cut`)."},
-                    {"name": "/settings region `[region]`", "desc": "Set the guild's primary operational region."},
+                    {"name": "/settings [subcommand]", "desc": "View a setting by calling it without options."},
+                    {"name": "/settings [roles]", "desc": "Set or clear permission roles (e.g., `admin_roles`)."},
+                    {"name": "/settings landsraad [action]", "desc": "Manage the Landsraad conversion bonus."},
+                    {"name": "/settings [cuts]", "desc": "Set default percentages for `/split` (e.g., `user_cut`)."},
+                    {"name": "/settings region [region]", "desc": "Set the guild's primary operational region."},
                 ]
             },
             {
                 "title": "System Commands",
                 "commands": [
-                    {"name": "/reset `confirm:True`", "desc": "Reset all data (Admin Only)."},
+                    {"name": "/reset [confirm]", "desc": "Reset all data (Admin Only)."},
                     {"name": "/sync", "desc": "Sync commands with Discord (Bot Owner Only)."},
                 ]
             }


### PR DESCRIPTION
This commit comprehensively updates the bot's documentation and refactors the `/help` command to be robust, user-friendly, and free of errors.

The changes include:
- Refactoring the `/help` command to use a new `StaticPaginatedView`, resolving the Discord character limit error by splitting the help text into multiple, navigable pages with a clean layout.
- Creating a new `StaticPaginatedView` class in `utils/pagination_utils.py` to handle pagination of static `discord.Embed` lists.
- Updating `commands/help.py` and `README.md` to include all current commands, including the previously missing `/guild` command group.
- Reorganizing the command documentation in both files into clear, consistent categories for better readability.
- Correcting the documentation for the `/settings` command to reflect its proper usage.
- Correcting all formatting issues with command parameters for a professional look.
- Adding a new unit test for the paginated `/help` command to ensure its functionality and prevent future regressions.
- Correcting the function signature of the `help` command to be compatible with the project's command decorator and integration tests, resolving all previous test failures.