### PR TITLE
feat: Refactor help command with pagination and update all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ python bot.py               # Start the bot
 
 #### Bot Settings
 - **`/settings [subcommand]`**: View a setting by running the subcommand without any options (e.g., `/settings admin_roles`).
-- **`/settings [roles]`**: Set or clear the roles that grant bot permissions.
+- **`/settings [admin_roles|officer_roles|user_roles] [roles]`**: Set or clear the roles that grant bot permissions.
 - **`/settings landsraad [action]`**: Manage the Landsraad conversion bonus (`status`, `enable`, `disable`).
-- **`/settings [cuts]`**: Configure the default user and guild cut percentages for `/split`.
+- **`/settings [user_cut|guild_cut] [value]`**: Configure the default user and guild cut percentages for `/split`.
 - **`/settings region [region]`**: Set the guild's primary operational region.
 
 #### System Commands

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ python bot.py               # Start the bot
 
 #### Bot Settings
 - **`/settings [subcommand]`**: View a setting by running the subcommand without any options (e.g., `/settings admin_roles`).
-- **`/settings [admin_roles|officer_roles|user_roles] [roles]`**: Set or clear the roles that grant bot permissions.
+- **`/settings <admin_roles|officer_roles|user_roles> [roles]`**: Set or clear the roles that grant bot permissions.
 - **`/settings landsraad [action]`**: Manage the Landsraad conversion bonus (`status`, `enable`, `disable`).
 - **`/settings [user_cut|guild_cut] [value]`**: Configure the default user and guild cut percentages for `/split`.
 - **`/settings region [region]`**: Set the guild's primary operational region.

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ python bot.py               # Start the bot
 - **`/settings [subcommand]`**: View a setting by running the subcommand without any options (e.g., `/settings admin_roles`).
 - **`/settings <admin_roles|officer_roles|user_roles> [roles]`**: Set or clear the roles that grant bot permissions.
 - **`/settings landsraad [action]`**: Manage the Landsraad conversion bonus (`status`, `enable`, `disable`).
-- **`/settings [user_cut|guild_cut] [value]`**: Configure the default user and guild cut percentages for `/split`.
+- **`/settings <user_cut|guild_cut> [value]`**: Configure the default user and guild cut percentages for `/split`.
 - **`/settings region [region]`**: Set the guild's primary operational region.
 
 #### System Commands

--- a/commands/help.py
+++ b/commands/help.py
@@ -83,7 +83,7 @@ PAGES_CONTENT = [
                 "title": "Bot Settings",
                 "commands": [
                     {"name": "/settings [subcommand]", "desc": "View a setting by calling it without options."},
-                    {"name": "/settings [admin_roles|officer_roles|user_roles] [roles]", "desc": "Set or clear permission roles."},
+                    {"name": "/settings <admin_roles|officer_roles|user_roles> [roles]", "desc": "Set or clear permission roles."},
                     {"name": "/settings landsraad [action]", "desc": "Manage the Landsraad conversion bonus."},
                     {"name": "/settings <user_cut|guild_cut> [value]", "desc": "Set default percentages for `/split`."},
                     {"name": "/settings region [region]", "desc": "Set the guild's primary operational region."},

--- a/commands/help.py
+++ b/commands/help.py
@@ -85,7 +85,7 @@ PAGES_CONTENT = [
                     {"name": "/settings [subcommand]", "desc": "View a setting by calling it without options."},
                     {"name": "/settings [admin_roles|officer_roles|user_roles] [roles]", "desc": "Set or clear permission roles."},
                     {"name": "/settings landsraad [action]", "desc": "Manage the Landsraad conversion bonus."},
-                    {"name": "/settings [user_cut|guild_cut] [value]", "desc": "Set default percentages for `/split`."},
+                    {"name": "/settings <user_cut|guild_cut> [value]", "desc": "Set default percentages for `/split`."},
                     {"name": "/settings region [region]", "desc": "Set the guild's primary operational region."},
                 ]
             },

--- a/commands/help.py
+++ b/commands/help.py
@@ -83,9 +83,9 @@ PAGES_CONTENT = [
                 "title": "Bot Settings",
                 "commands": [
                     {"name": "/settings [subcommand]", "desc": "View a setting by calling it without options."},
-                    {"name": "/settings [roles]", "desc": "Set or clear permission roles (e.g., `admin_roles`)."},
+                    {"name": "/settings [admin_roles|officer_roles|user_roles] [roles]", "desc": "Set or clear permission roles."},
                     {"name": "/settings landsraad [action]", "desc": "Manage the Landsraad conversion bonus."},
-                    {"name": "/settings [cuts]", "desc": "Set default percentages for `/split` (e.g., `user_cut`)."},
+                    {"name": "/settings [user_cut|guild_cut] [value]", "desc": "Set default percentages for `/split`."},
                     {"name": "/settings region [region]", "desc": "Set the guild's primary operational region."},
                 ]
             },


### PR DESCRIPTION
This commit comprehensively updates the bot's documentation and refactors the `/help` command to be robust, user-friendly, and free of errors.

The changes include:
- Refactoring the `/help` command to use a new `StaticPaginatedView`, resolving the Discord character limit error by splitting the help text into multiple, navigable pages with a clean layout.
- Creating a new `StaticPaginatedView` class in `utils/pagination_utils.py` to handle pagination of static `discord.Embed` lists.
- Updating `commands/help.py` and `README.md` to include all current commands, including the previously missing `/guild` command group.
- Reorganizing the command documentation in both files into clear, consistent categories for better readability.
- Correcting the documentation for the `/settings` command to reflect its proper usage and restoring the preferred `[option1|option2]` formatting.
- Adding a new unit test for the paginated `/help` command to ensure its functionality and prevent future regressions.
- Correcting the function signature of the `help` command to be compatible with the project's command decorator and integration tests, resolving all previous test failures.