### PR TITLE
feat: Refactor help command with pagination and update all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,39 +115,43 @@ python bot.py               # Start the bot
 
 ## 🤖 Commands
 
-### 🏜️ Harvester Commands
-- **`/sand <amount>`** - Convert spice sand to melange (1-10,000). Primary currency conversion at 50:1 ratio
-- **`/refinery`** - View your melange production and payment status (private)
-- **`/ledger`** - View your sand conversion history and melange status (private)
-- **`/leaderboard [limit]`** - Display top spice refiners by melange production (optionally set a limit)
-- **`/expedition <expedition_id>`** - View details of a specific expedition
-- **`/help`** - Display all available commands (private)
- - **`/perms`** - Show your permission status and matched roles (private)
- - **`/water [destination]`** - Request a water delivery (default: "DD base")
+### General Commands
+- **`/help`**: Show the list of all available commands.
+- **`/perms`**: Check your current permission level and the roles that grant it.
+- **`/calc <amount>`**: Estimate the melange output for a given amount of sand without starting a conversion.
 
-### 🚀 Team Commands
-- **`/split <total_sand> <users> [guild]`** - Split spice sand among expedition members and convert to melange
-  - **Example:** `/split 10000 "@harvester 30 @scout @pilot" 15`
-  - **Guild Cut:** Percentage taken off the top (default: 10%)
-  - **User Percentages:** Users with percentages get exact amounts, others split equally
-  - **Creates:** Expedition records and tracks melange owed for payout
+### Harvester Commands
+- **`/sand <amount>`**: Convert your spice sand into melange.
+- **`/refinery`**: View your personal melange production statistics and current payment status.
+- **`/ledger`**: See a detailed history of your personal sand-to-melange conversions.
+- **`/leaderboard [limit]`**: Display the top melange producers in the guild.
+- **`/split <sand> <users>`**: Split a sand haul with other users, applying guild cuts and converting it to melange for everyone.
+- **`/expedition <id>`**: Look up the details of a past split/expedition.
+- **`/water [destination]`**: Request a water delivery to a specified location.
 
-### 🏛️ Guild Admin Commands
- - **`/reset confirm:True`** - Reset all refinery statistics (requires confirmation)
- - **`/pending`** - View all users with pending melange payments and amounts owed
- - **`/pay <user> [amount]`** - Process payment for a specific harvester (defaults to full pending)
- - **`/payroll`** - Process payments for all unpaid harvesters at once
- - **`/guild_withdraw <user> <amount>`** - Withdraw resources from guild treasury to give to a user
- - **`/landsraad <action> [confirm]`** - Manage landsraad bonus (status/enable/disable)
-  - **Status:** Check current conversion rate (50:1 or 37.5:1)
-  - **Enable:** Activate landsraad bonus (37.5 sand = 1 melange)
-  - **Disable:** Return to normal rate (50 sand = 1 melange)
+### Admin & Officer Commands
 
-### 🧾 User/Finance Viewing
- - **`/treasury`** - View guild treasury balance and melange reserves
+#### User & Payroll Management
+- **`/pending`**: View a list of all users with pending (unpaid) melange.
+- **`/pay <user> [amount]`**: Pay a user their owed melange.
+- **`/payroll <confirm>`**: Initiate a payroll run to pay all users all their pending melange.
 
-### 🔧 Bot Owner Commands
-- **`/sync`** - Sync slash commands (Bot Owner Only)
+#### Guild Management
+- **`/guild treasury`**: View the guild's current treasury balance.
+- **`/guild withdraw <user> <amount>`**: Withdraw melange from the guild treasury and credit it to a user.
+- **`/guild transactions`**: View the guild's complete transaction history.
+- **`/guild payouts`**: View the guild's complete melange payout history.
+
+#### Bot Settings
+- **`/settings [subcommand]`**: View a setting by running the subcommand without any options (e.g., `/settings admin_roles`).
+- **`/settings <admin_roles|officer_roles|user_roles> [roles]`**: Set or clear the roles that grant bot permissions.
+- **`/settings landsraad [action]`**: Manage the Landsraad conversion bonus (`status`, `enable`, `disable`).
+- **`/settings <user_cut|guild_cut> [value]`**: Configure the default user and guild cut percentages for `/split`.
+- **`/settings region [region]`**: Set the guild's primary operational region.
+
+#### System Commands
+- **`/reset <confirm>`**: **(Admin Only)** Reset all refinery and user data. This is irreversible.
+- **`/sync`**: **(Bot Owner Only)** Manually sync application commands with Discord.
 
 ## 📊 How It Works
 

--- a/commands/help.py
+++ b/commands/help.py
@@ -2,55 +2,141 @@
 Help command for showing all available spice tracking commands.
 """
 
+import discord
+from utils.embed_utils import build_status_embed
+from utils.base_command import command
+from utils.pagination_utils import StaticPaginatedView
+
 # Command metadata
 COMMAND_METADATA = {
-    'aliases': [],  # ['commands'] - removed for simplicity
+    'aliases': [],
     'description': "Show all available spice tracking commands",
     'permission_level': 'any'
 }
 
-import os
-from utils.embed_utils import build_status_embed
-from utils.base_command import command
-from utils.helpers import send_response
+# Define the content for each page
+PAGES_CONTENT = [
+    {
+        "title": "General Commands",
+        "base_description": "Commands available to everyone.",
+        "color": 0x3498DB,
+        "sections": [
+            {
+                "title": "",
+                "commands": [
+                    {"name": "/help", "desc": "Show this list of commands."},
+                    {"name": "/perms", "desc": "Check your current permission level."},
+                    {"name": "/calc [amount]", "desc": "Estimate melange from sand without saving."},
+                ]
+            }
+        ]
+    },
+    {
+        "title": "Harvester Commands",
+        "base_description": "Commands for tracking sand and melange.",
+        "color": 0x2ECC71,
+        "sections": [
+            {
+                "title": "",
+                "commands": [
+                    {"name": "/sand [amount]", "desc": "Convert your sand into melange."},
+                    {"name": "/refinery", "desc": "View your melange production and payment status."},
+                    {"name": "/ledger", "desc": "View your personal conversion history."},
+                    {"name": "/leaderboard [limit]", "desc": "See the top melange producers."},
+                    {"name": "/split [sand] [users]", "desc": "Split sand with others and convert it to melange."},
+                    {"name": "/expedition [id]", "desc": "View the details of a specific split/expedition."},
+                    {"name": "/water [destination]", "desc": "Request a water delivery."},
+                ]
+            }
+        ]
+    },
+    {
+        "title": "Admin & Officer Commands (1/2)",
+        "base_description": "Management commands for officers and admins.",
+        "color": 0xE74C3C,
+        "sections": [
+            {
+                "title": "User & Payroll Management",
+                "commands": [
+                    {"name": "/pending", "desc": "View all users with pending (unpaid) melange."},
+                    {"name": "/pay [user] [amount]", "desc": "Pay a user their pending melange."},
+                    {"name": "/payroll [confirm]", "desc": "Pay all users with pending melange at once."},
+                ]
+            },
+            {
+                "title": "Guild Management",
+                "commands": [
+                    {"name": "/guild treasury", "desc": "View the guild's treasury balance."},
+                    {"name": "/guild withdraw [user] [amount]", "desc": "Withdraw melange from the treasury to a user."},
+                    {"name": "/guild transactions", "desc": "View the guild's transaction history."},
+                    {"name": "/guild payouts", "desc": "View the guild's melange payout history."},
+                ]
+            }
+        ]
+    },
+    {
+        "title": "Admin & Officer Commands (2/2)",
+        "base_description": "Configuration and system commands for admins.",
+        "color": 0xE74C3C,
+        "sections": [
+            {
+                "title": "Bot Settings",
+                "commands": [
+                    {"name": "/settings [subcommand]", "desc": "View a setting by calling it without options."},
+                    {"name": "/settings <admin_roles|officer_roles|user_roles> [roles]", "desc": "Set or clear permission roles."},
+                    {"name": "/settings landsraad [action]", "desc": "Manage the Landsraad conversion bonus."},
+                    {"name": "/settings <user_cut|guild_cut> [value]", "desc": "Set default percentages for `/split`."},
+                    {"name": "/settings region [region]", "desc": "Set the guild's primary operational region."},
+                ]
+            },
+            {
+                "title": "System Commands",
+                "commands": [
+                    {"name": "/reset [confirm]", "desc": "Reset all data (Admin Only)."},
+                    {"name": "/sync", "desc": "Sync commands with Discord (Bot Owner Only)."},
+                ]
+            }
+        ]
+    }
+]
+
+def build_help_pages(interaction: discord.Interaction) -> list[discord.Embed]:
+    """Builds a list of embed pages for the help command."""
+    pages = []
+    total_pages = len(PAGES_CONTENT)
+    for i, page_content in enumerate(PAGES_CONTENT):
+        # Combine all sections into a single description string
+        description = page_content['base_description']
+
+        for section in page_content['sections']:
+            if section['title']:
+                description += f"\n\n**__{section['title']}__**"
+
+            command_list = []
+            for command in section['commands']:
+                command_list.append(f"**`{command['name']}`** - {command['desc']}")
+            description += "\n" + "\n".join(command_list)
+
+        embed = build_status_embed(
+            title=f"🏜️ Help: {page_content['title']}",
+            description=description,
+            color=page_content['color'],
+            timestamp=interaction.created_at
+        )
+        embed.set_footer(text=f"Page {i + 1}/{total_pages} • Use the buttons to navigate.")
+        pages.append(embed.build())
+    return pages
 
 
 @command('help')
-async def help(interaction, command_start, use_followup: bool = True):
-    """Show all available commands and their descriptions"""
+async def help(interaction: discord.Interaction, command_start, **kwargs):
+    """Show all available commands and their descriptions using a paginated view."""
+    pages = build_help_pages(interaction)
+    view = StaticPaginatedView(interaction=interaction, pages=pages)
 
-    # Use utility function for embed building
-    fields = {
-        "📊 Harvester Commands": "**`/sand [amount]`** Convert sand→melange (1-10k, 50:1 ratio)\n"
-                                 "**`/refinery`** View melange status & payments\n"
-                                 "**`/ledger`** View conversion history & status\n"
-                                 "**`/expedition [id]`** View expedition details\n"
-                                 "**`/leaderboard [limit]`** Top refiners (5-25 users)\n"
-                                 "**`/split [sand] [@users]`** Split sand→melange with guild cut\n"
-                                 "**`/water [destination]`** Request water delivery\n"
-                                 "**`/help`** Show all commands",
-        "⚙️ Admin Commands": "**`/sync`** Sync commands (Owner)\n"
-                                   "**`/reset confirm:True`** Reset all data",
-        "🏛️ Officer Commands": "**`/pending`** View pending melange payments\n"
-                                   "**`/pay [user] [amount]`** Process user payment (full or partial)\n"
-                                   "**`/payroll`** Pay all users\n"
-                                   "**`/treasury`** View guild treasury\n"
-                                   "**`/guild_withdraw [user] [amount]`** Treasury withdrawal\n"
-                                   "**`/landsraad [action]`** Manage conversion bonus (37.5:1 rate)",
-
-        "💡 Examples": "• `/sand 250` → 5 melange\n"
-                            "• `/split 1000 @user1 @user2` → 500 each\n"
-                            "• `/water Spice Fields` → request water delivery\n"
-                            "• `/pay @user` → pay pending melange\n"
-                            "• `/payroll` → pay all users"
-    }
-
-    embed = build_status_embed(
-        title="🏜️ Spice Refinery Commands",
-        description="Sand→melange conversion & production tracking",
-        color=0xF39C12,
-        fields=fields,
-        timestamp=interaction.created_at
+    # The decorator already defers the response, so we use a followup.
+    await interaction.followup.send(
+        embed=pages[0],
+        view=view,
+        ephemeral=True
     )
-
-    await send_response(interaction, embed=embed.build(), use_followup=use_followup, ephemeral=True)


### PR DESCRIPTION
This commit comprehensively updates the bot's documentation and refactors the `/help` command to be robust and user-friendly.

The changes include:
- Refactoring the `/help` command to use a new `StaticPaginatedView`, resolving the Discord character limit error by splitting the help text into multiple, navigable pages.
- Creating a new `StaticPaginatedView` class in `utils/pagination_utils.py` to handle pagination of static `discord.Embed` lists.
- Updating `commands/help.py` and `README.md` to include all current commands, including the previously missing `/guild` command group.
- Reorganizing the command documentation in both files into clear, consistent categories for better readability.
- Correcting the documentation for the `/settings` command to reflect its proper usage.
- Adding a new unit test for the paginated `/help` command to ensure its functionality and prevent future regressions.
- Correcting the function signature of the `help` command to be compatible with the project's command decorator and integration tests.